### PR TITLE
Fix MLP's batchnorm step by removing size and mode checks

### DIFF
--- a/flexynesis/modules.py
+++ b/flexynesis/modules.py
@@ -136,8 +136,7 @@ class MLP(nn.Module):
             x (torch.Tensor): The output tensor after passing through the MLP network.
         """
         x = self.layer_1(x)
-        if (x.size(0) != 1) and self.training:  # Skip BatchNorm if batch size is 1
-            x = self.batchnorm(x)
+        x = self.batchnorm(x)
         x = self.relu(x)
         x = self.dropout(x)
         x = self.layer_out(x)


### PR DESCRIPTION
This PR fixes a bug in batchnorm execution step for MLP

The correct way of doing this is:
```python
if ((x.size(0) != 1) and self.training) or (not self.training):
```
BUT doing shuffling with drop last during training is enough:

`DataLoader(..., shuffle=True, drop_last=True)`

