### PR TITLE
Fix missing `models` installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,8 +50,8 @@ test = [
     "pytest"
 ]
 
-[tool.setuptools]
-packages = ["flexynesis"]
+[tool.setuptools.packages.find]
+include = ["flexynesis.*"]
 
 [tool.pytest.ini_options]
 norecursedirs = [


### PR DESCRIPTION
For the future:


```json
      configuration error: `tool.setuptools.packages` must be valid exactly by one definition (0 matches found):
      
          - type: array
            items:
              type: string
              at least one of the following:
                - {format: 'python-module-name'}
                - {format: 'pep561-stub-name'}
          - type: table
            additional keys: False
            keys:
              'find':
                type: table
                additional keys: False
                keys:
                  'where':
                    type: array
                    items: {type: string}
                  'exclude':
                    type: array
                    items: {type: string}
                  'include':
                    type: array
                    items: {type: string}
                  'namespaces': {type: boolean}
      
      DESCRIPTION:
          Packages that should be included in the distribution. It can be given either
          as a list of package identifiers or as a ``dict``-like structure with a
          single key ``find`` which corresponds to a dynamic call to
          ``setuptools.config.expand.find_packages`` function. The ``find`` key is
          associated with a nested ``dict``-like structure that can contain ``where``,
          ``include``, ``exclude`` and ``namespaces`` keys, mimicking the keyword
          arguments of the associated function.
      
      GIVEN VALUE:
          [
              "flexynesis*"
          ]
      
      OFFENDING RULE: 'oneOf'
      
      DEFINITION:
          {
              "oneOf": [
                  {
                      "title": "Array of Python package identifiers",
                      "type": "array",
                      "items": {
                          "$id": "#/definitions/package-name",
                          "title": "Valid package name",
                          "description": "Valid package name (importable or PEP 561).",
                          "type": "string",
                          "anyOf": [
                              {
                                  "format": "python-module-name"
                              },
                              {
                                  "format": "pep561-stub-name"
                              }
                          ]
                      }
                  },
                  {
                      "$id": "#/definitions/find-directive",
                      "title": "'find:' directive",
                      "type": "object",
                      "additionalProperties": false,
                      "properties": {
                          "find": {
                              "type": "object",
                              "$$description": [
                                  "Dynamic `package discovery",
                                  "<https://setuptools.pypa.io/en/latest/userguide/package_discovery.html>`_."
                              ],
                              "additionalProperties": false,
                              "properties": {
                                  "where": {
                                      "description": "Directories to be searched for packages (Unix-style relative path)",
                                      "type": "array",
                                      "items": {
                                          "type": "string"
                                      }
                                  },
                                  "exclude": {
                                      "type": "array",
                                      "$$description": [
                                          "Exclude packages that match the values listed in this field.",
                                          "Can container shell-style wildcards (e.g. ``'pkg.*'``)"
                                      ],
                                      "items": {
                                          "type": "string"
                                      }
                                  },
                                  "include": {
                                      "type": "array",
                                      "$$description": [
                                          "Restrict the found packages to just the ones listed in this field.",
                                          "Can container shell-style wildcards (e.g. ``'pkg.*'``)"
                                      ],
                                      "items": {
                                          "type": "string"
                                      }
                                  },
                                  "namespaces": {
                                      "type": "boolean",
                                      "$$description": [
                                          "When ``True``, directories without a ``__init__.py`` file will also",
                                          "be scanned for :pep:`420`-style implicit namespaces"
                                      ]
                                  }
                              }
                          }
                      }
                  }
              ]
          }

```