### PR TITLE
[Fix] Issue 156: Label missing in train but existing in test -> Encoder

### DIFF
--- a/flexynesis/utils.py
+++ b/flexynesis/utils.py
@@ -780,11 +780,15 @@ def get_predicted_labels(y_pred_dict, dataset, split, method_name):
             y_true = [
                 (
                     dataset.label_mappings[var][int(x.item())]
-                    if var in dataset.label_mappings.keys() and not np.isnan(x.item())
-                    else np.nan
+                    if var in dataset.label_mappings.keys() and not np.isnan(x.item()) and not int(x.item()) == -1
+                    else "Label_not_in_train"  # catches samples ann defaulted to -1 (usually label in test but not in train) # See issue #156
+                    if int(x.item()) == -1
+                    else np.nan 
                 )
                 for x in dataset.ann[var]
             ]
+            if "Label_not_in_train" in y_true: # See issue #156
+                print(f"[WARNING] Encoder Defaults. Some {var} values are present in test but not in test") # See issue #156
 
             # Predicted labels (argmax of probabilities)
             y_pred_indices = np.argmax(probabilities, axis=1)


### PR DESCRIPTION
- won't fail if label not in train but in test for categorical
- Notifies the User in  case of "missing label"
- catches all ann == -1 in categoral 