### PR TITLE
Gnn improvement

### DIFF
--- a/examples/configs/hpo_configuration.yaml
+++ b/examples/configs/hpo_configuration.yaml
@@ -121,6 +121,12 @@ GNN:
     name: supervisor_hidden_dim
     low: 8
     high: 32
+  # Fraction of nodes hidden for the masked-reconstruction loss. Omitting this
+  # entry falls back to 0.5; pinning it to 0 disables the auxiliary loss.
+  - type: Real
+    name: gnn_mask_ratio
+    low: 0.1
+    high: 0.7
   - type: Categorical
     name: batch_size
     categories: [32, 64, 128]

--- a/flexynesis/__main__.py
+++ b/flexynesis/__main__.py
@@ -81,7 +81,7 @@ def print_full_help():
         "usage: flexynesis [-h] --data_path DATA_PATH --model_class "
         "{DirectPred,supervised_vae,MultiTripletNetwork,CrossModalPred,GNN,"
         "RandomForest,SVM,XGBoost,RandomSurvivalForest} "
-        "[--gnn_conv_type {GC,GCN,SAGE}] [--target_variables TARGET_VARIABLES] "
+        "[--gnn_conv_type {GC,GCN,SAGE}] [--use_edge_weights] [--target_variables TARGET_VARIABLES] "
         "[--covariates COVARIATES] [--surv_event_var SURV_EVENT_VAR] "
         "[--surv_time_var SURV_TIME_VAR] [--config_path CONFIG_PATH] "
         "[--fusion_type {early,intermediate}] [--hpo_iter HPO_ITER] "
@@ -135,6 +135,11 @@ def print_full_help():
     print(
         "                        If model_class is set to GNN, choose which graph "
         "convolution type to use"
+    )
+    print("  --use_edge_weights")
+    print(
+        "                        If model_class is set to GNN, weight graph edges "
+        "by the network's scores rather than treating every edge as equal"
     )
     print("  --target_variables TARGET_VARIABLES")
     print(
@@ -538,6 +543,15 @@ def main():
         type=str,
         choices=["GC", "GCN", "SAGE"],
         help="If model_class is set to GNN, choose which graph convolution type to use",
+    )
+    parser.add_argument(
+        "--use_edge_weights",
+        action="store_true",
+        help="If model_class is set to GNN, weight graph edges by the network's "
+        "scores instead of treating every edge as equal. Scores are normalised "
+        "to [0, 1], where 0 means no connection, so a graph may list a gene with "
+        "only zero-weight edges to keep it as an isolated node. Ignored by SAGE, "
+        "which cannot use edge weights.",
     )
     parser.add_argument(
         "--target_variables",
@@ -1305,6 +1319,7 @@ def main():
             early_stop_patience=int(args.early_stop_patience),
             device_type=device_type,
             gnn_conv_type=gnn_conv_type,
+            use_edge_weights=args.use_edge_weights,
             input_layers=input_layers,
             output_layers=output_layers,
             num_workers=args.num_workers,

--- a/flexynesis/__main__.py
+++ b/flexynesis/__main__.py
@@ -891,7 +891,10 @@ def main():
         if not os.path.exists(args.artifacts):
             raise FileNotFoundError(f"--artifacts not found: {args.artifacts}")
 
-        if not isinstance(args.finetuning_samples, int) and not os.path.exists(args.finetuning_samples):   # In case of finetune.  case sample ID file -> Check if file exist
+        # In case of finetune. case sample ID file -> check the file exists
+        if not isinstance(args.finetuning_samples, int) and not os.path.exists(
+            args.finetuning_samples
+        ):
             raise FileNotFoundError(f"--finetunesamples Not int and File not found: {args.finetuning_samples}")
 
         # Handle device selection for inference (same logic as training)
@@ -1016,32 +1019,30 @@ def main():
         print(f"[INFO] Test dataset loaded: {len(test_dataset.samples)} samples")
 
     # Import evaluation utilities needed in the shared evaluation section below
-    import pandas as pd  
+    import pandas as pd
 
-    from .utils import evaluate_wrapper, get_predicted_labels  
+    from .utils import evaluate_wrapper, get_predicted_labels
 
     # Continue to evaluation section (skip training)
 
     # ------------- Heavy imports only when training or in inference with evaluation ---
     if not (args.pretrained_model and args.artifacts and args.data_path_test):
-        import json  
-        import tracemalloc  
+        import json
+        import tracemalloc
 
-        import torch  
-        from safetensors.torch import save_file  # 
+        import torch
 
         # data + utils
-        from .data import (STRING, DataImporter,  
-                           MultiOmicDatasetNW)
-        from .main import HyperparameterTuning  
-        from .models.crossmodal_pred import CrossModalPred  
+        from .data import STRING, DataImporter, MultiOmicDatasetNW
+        from .main import HyperparameterTuning
+        from .models.crossmodal_pred import CrossModalPred
         # models
-        from .models.direct_pred import DirectPred  
-        from .models.gnn_early import GNN  
-        from .models.supervised_vae import supervised_vae  
-        from .models.triplet_encoder import MultiTripletNetwork  
-        from .utils import evaluate_baseline_performance  
-        from .utils import (evaluate_baseline_survival_performance,
+        from .models.direct_pred import DirectPred
+        from .models.gnn_early import GNN
+        from .models.supervised_vae import supervised_vae
+        from .models.triplet_encoder import MultiTripletNetwork
+        from .utils import (evaluate_baseline_performance,
+                            evaluate_baseline_survival_performance,
                             get_device_memory_info, get_optimal_device)
 
         # --------- Sanity checks on args ---------
@@ -1219,7 +1220,7 @@ def main():
         # classical ML baselines
         if args.model_class == "XGBoost":
             try:
-                from xgboost import XGBClassifier  
+                from xgboost import XGBClassifier  # noqa: F401
             except Exception:
                 raise ImportError(
                     "XGBoost is not available. On macOS, install the OpenMP runtime: "
@@ -1369,16 +1370,14 @@ def main():
         model, best_params = tuner.perform_tuning(hpo_patience=args.hpo_patience)
 
     # if fine-tuning is enabled; fine tune the model on a portion of test samples
-    finetune_dataset = None # Will capture the Finetunesamples for the predicted_label output
+    finetune_dataset = None  # captures the Finetunesamples for predicted_label
     if args.finetuning_samples != 0:
         from .main import FineTuner
 
         finetune_indices = None
         all_indices = range(len(test_dataset))
-        
-       
 
-        if isinstance(args.finetuning_samples,int): # Usual Finetune Path if int is Provided
+        if isinstance(args.finetuning_samples, int):  # usual path when an int is given
             finetuneSampleN = args.finetuning_samples
             print(
                 "[INFO] Finetuning the model on ",
@@ -1388,29 +1387,40 @@ def main():
             # split test dataset into finetuning and holdout datasets
             import random as _random
             finetune_indices = _random.sample(list(all_indices), finetuneSampleN)
-        else: 
+        else:
             provided_samples = None
-            with open(args.finetuning_samples,"r") as f:
-                lines = [line.strip() for line in f.readlines()]    #ATENTION this functionality expects the IDS to be Atomic and seperate in each line further extend for single line seperated by " " or ","
+            with open(args.finetuning_samples, "r") as f:
+                # ATENTION this functionality expects the IDS to be Atomic and
+                # seperate in each line; extend for a single line seperated by
+                # " " or ","
+                lines = [line.strip() for line in f.readlines()]
                 provided_samples = lines
-                
+
             if len(provided_samples) == 0:
                 raise ValueError(f"Finetunsample file is empty: {args.finetuning_samples}")
-                
-            #Check if All Given IDS are in Dataset. Happens if given featurres do not contain ID
+
+            # Check if All Given IDS are in Dataset. Happens if given featurres do not contain ID
             if not set(provided_samples).issubset(set(test_dataset.samples)):
                 missing = set(provided_samples) - set(test_dataset.samples)
                 if len(missing) < 15:
-                    raise ValueError (f"{len(missing)} sample(s) not found in reference file: {sorted(missing)}")
-                else: 
-                    raise ValueError (f"{len(missing)} sample(s) not found in reference file: {sorted(missing[:15])} and more")
-            if isinstance(test_dataset.samples,list):
+                    raise ValueError(
+                        f"{len(missing)} sample(s) not found in reference file: {sorted(missing)}"
+                    )
+                else:
+                    raise ValueError(
+                        f"{len(missing)} sample(s) not found in reference file: "
+                        f"{sorted(missing)[:15]} and more"
+                    )
+            if isinstance(test_dataset.samples, list):
                 finetune_indices = [test_dataset.samples.index(sampleid) for sampleid in provided_samples]
             else:
-                raise TypeError(f"train_dataset samples stored not as List but as {type(test_dataset.samples) = }") ##Might be superfluis but idk if samples could be passed as something else
-            
-                
-            
+                # Might be superfluis but idk if samples could be passed as
+                # something else
+                raise TypeError(
+                    "train_dataset samples stored not as List but as "
+                    f"{type(test_dataset.samples) = }"
+                )
+
         holdout_indices = list(set(all_indices) - set(finetune_indices))
         finetune_dataset = test_dataset.subset(finetune_indices)
         holdout_dataset = test_dataset.subset(holdout_indices)
@@ -1468,7 +1478,8 @@ def main():
                     f"[INFO] Subsampling {captum_sample_cap} of {len(train_dataset)} "
                     "training samples for Captum feature importance"
                 )
-                import random; random.seed(42)
+                import random
+                random.seed(42)
                 captum_indices = random.sample(range(len(train_dataset)), captum_sample_cap)
                 captum_dataset = train_dataset.subset(captum_indices)
             else:
@@ -1547,7 +1558,7 @@ def main():
                 ],
                 ignore_index=True,
             )
-        else :
+        else:
             predicted_labels = get_predicted_labels(
                 model.predict(test_dataset),
                 test_dataset,
@@ -1759,9 +1770,9 @@ def main():
                 print(f"[INFO] Wrote inference artifacts to {joblib_path}")
 
             elif args.safetensors:
-                import numpy as np  
-                from sklearn.preprocessing import LabelEncoder  
-                from sklearn.preprocessing import (OrdinalEncoder,
+                import numpy as np
+                from sklearn.preprocessing import (LabelEncoder,
+                                                   OrdinalEncoder,
                                                    StandardScaler)
 
                 json_ready = {

--- a/flexynesis/__main__.py
+++ b/flexynesis/__main__.py
@@ -137,12 +137,11 @@ def print_full_help():
         "convolution type to use"
     )
     print("  --gnn_readout "
-          "{mean,sum,max,meanmax,attention,dim_attention}")
+          "{mean,sum,max,meanmax,attention,dim_attention,flatten}")
     print(
-        "                        How the GNN pools node embeddings; pooling "
-        "makes the graph structure load-bearing"
+        "                        How the GNN reduces per-node embeddings to "
+        "one vector per sample"
     )
-    print("  --gnn_no_projection")
     print(
         "                        Use the pooled node embeddings as the sample "
         "representation instead of projecting to latent_dim"
@@ -560,20 +559,15 @@ def main():
     parser.add_argument(
         "--gnn_readout",
         type=str,
-        choices=["mean", "sum", "max", "meanmax", "attention", "dim_attention"],
+        choices=["mean", "sum", "max", "meanmax", "attention", "dim_attention",
+                 "flatten"],
         default="dim_attention",
-        help="How the GNN reduces per-node embeddings to one vector per sample. "
-        "Every option reduces the node axis, so no weight is tied to a node's "
-        "index and node information has to travel along edges. 'dim_attention' "
-        "attends over each node's embedding dimensions instead, giving one "
-        "value per gene, which keeps gene identity",
-    )
-    parser.add_argument(
-        "--gnn_no_projection",
-        action="store_true",
-        help="Skip the projection into latent_dim and use the pooled node "
-        "embeddings directly as the sample representation, so it stays a "
-        "combination of node embeddings driven by the graph",
+        help="How the GNN reduces per-node embeddings to one vector per "
+        "sample. 'mean'/'sum'/'max'/'meanmax'/'attention' pool over the node "
+        "axis, discarding which node carried a value. 'dim_attention' attends "
+        "over each node's embedding dimensions instead, giving one value per "
+        "node. 'flatten' concatenates every node's full embedding, which keeps "
+        "the most node-level detail but scales with the node count",
     )
     parser.add_argument(
         "--seed",
@@ -1366,7 +1360,6 @@ def main():
             gnn_conv_type=gnn_conv_type,
             use_edge_weights=not args.disable_edge_weighting,
             gnn_readout=args.gnn_readout,
-            gnn_project=not args.gnn_no_projection,
             input_layers=input_layers,
             output_layers=output_layers,
             num_workers=args.num_workers,

--- a/flexynesis/__main__.py
+++ b/flexynesis/__main__.py
@@ -136,6 +136,13 @@ def print_full_help():
         "                        If model_class is set to GNN, choose which graph "
         "convolution type to use"
     )
+    print("  --gnn_readout {flatten,mean,sum,max,meanmax}")
+    print(
+        "                        How the GNN pools node embeddings; pooling "
+        "makes the graph structure load-bearing"
+    )
+    print("  --seed SEED")
+    print("                        Random seed (default 42)")
     print("  --use_edge_weights")
     print(
         "                        If model_class is set to GNN, weight graph edges "
@@ -545,6 +552,23 @@ def main():
         help="If model_class is set to GNN, choose which graph convolution type to use",
     )
     parser.add_argument(
+        "--gnn_readout",
+        type=str,
+        choices=["flatten", "mean", "sum", "max", "meanmax"],
+        default="flatten",
+        help="How the GNN reduces per-node embeddings to one vector per sample. "
+        "'flatten' concatenates every node, which keeps a weight per node and "
+        "lets the model bypass the graph; the pooling options are "
+        "permutation-invariant, so node information must travel along edges",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Random seed, for reproducible runs and for repeating a run "
+        "across seeds to estimate its variability",
+    )
+    parser.add_argument(
         "--use_edge_weights",
         action="store_true",
         help="If model_class is set to GNN, weight graph edges by the network's "
@@ -819,6 +843,12 @@ def main():
     )
 
     args = parser.parse_args()
+
+    # main.py seeds at import time with the default; re-seed here so --seed
+    # takes effect before any model or split is drawn.
+    from lightning import seed_everything
+
+    seed_everything(args.seed, workers=True)
 
     # --------- Conditional requirements & I/O prep (applies to both modes) ---------
     # Ensure outdir exists (works for training and inference)
@@ -1320,6 +1350,7 @@ def main():
             device_type=device_type,
             gnn_conv_type=gnn_conv_type,
             use_edge_weights=args.use_edge_weights,
+            gnn_readout=args.gnn_readout,
             input_layers=input_layers,
             output_layers=output_layers,
             num_workers=args.num_workers,

--- a/flexynesis/__main__.py
+++ b/flexynesis/__main__.py
@@ -141,6 +141,16 @@ def print_full_help():
         "                        How the GNN pools node embeddings; pooling "
         "makes the graph structure load-bearing"
     )
+    print("  --gnn_head {mlp,linear}")
+    print(
+        "                        Supervisor head; 'linear' forces the graph "
+        "embedding to carry the signal"
+    )
+    print("  --gnn_no_projection")
+    print(
+        "                        Use the pooled node embeddings as the sample "
+        "representation instead of projecting to latent_dim"
+    )
     print("  --seed SEED")
     print("                        Random seed (default 42)")
     print("  --use_edge_weights")
@@ -560,6 +570,22 @@ def main():
         "'flatten' concatenates every node, which keeps a weight per node and "
         "lets the model bypass the graph; the pooling options are "
         "permutation-invariant, so node information must travel along edges",
+    )
+    parser.add_argument(
+        "--gnn_head",
+        type=str,
+        choices=["mlp", "linear"],
+        default="mlp",
+        help="Supervisor head on top of the GNN embedding. 'linear' is a "
+        "single layer, so the embedding must already be linearly separable "
+        "and the graph cannot be compensated for downstream",
+    )
+    parser.add_argument(
+        "--gnn_no_projection",
+        action="store_true",
+        help="Skip the projection into latent_dim and use the pooled node "
+        "embeddings directly as the sample representation, so it stays a "
+        "combination of node embeddings driven by the graph",
     )
     parser.add_argument(
         "--seed",
@@ -1351,6 +1377,8 @@ def main():
             gnn_conv_type=gnn_conv_type,
             use_edge_weights=args.use_edge_weights,
             gnn_readout=args.gnn_readout,
+            gnn_head=args.gnn_head,
+            gnn_project=not args.gnn_no_projection,
             input_layers=input_layers,
             output_layers=output_layers,
             num_workers=args.num_workers,

--- a/flexynesis/__main__.py
+++ b/flexynesis/__main__.py
@@ -81,7 +81,7 @@ def print_full_help():
         "usage: flexynesis [-h] --data_path DATA_PATH --model_class "
         "{DirectPred,supervised_vae,MultiTripletNetwork,CrossModalPred,GNN,"
         "RandomForest,SVM,XGBoost,RandomSurvivalForest} "
-        "[--gnn_conv_type {GC,GCN,SAGE}] [--use_edge_weights] [--target_variables TARGET_VARIABLES] "
+        "[--gnn_conv_type {GC,GCN,SAGE}] [--disable_edge_weighting] [--target_variables TARGET_VARIABLES] "
         "[--covariates COVARIATES] [--surv_event_var SURV_EVENT_VAR] "
         "[--surv_time_var SURV_TIME_VAR] [--config_path CONFIG_PATH] "
         "[--fusion_type {early,intermediate}] [--hpo_iter HPO_ITER] "
@@ -136,15 +136,11 @@ def print_full_help():
         "                        If model_class is set to GNN, choose which graph "
         "convolution type to use"
     )
-    print("  --gnn_readout {flatten,mean,sum,max,meanmax}")
+    print("  --gnn_readout "
+          "{mean,sum,max,meanmax,attention,dim_attention}")
     print(
         "                        How the GNN pools node embeddings; pooling "
         "makes the graph structure load-bearing"
-    )
-    print("  --gnn_head {mlp,linear}")
-    print(
-        "                        Supervisor head; 'linear' forces the graph "
-        "embedding to carry the signal"
     )
     print("  --gnn_no_projection")
     print(
@@ -153,10 +149,10 @@ def print_full_help():
     )
     print("  --seed SEED")
     print("                        Random seed (default 42)")
-    print("  --use_edge_weights")
+    print("  --disable_edge_weighting")
     print(
-        "                        If model_class is set to GNN, weight graph edges "
-        "by the network's scores rather than treating every edge as equal"
+        "                        Ignore the network's edge scores; weighting is "
+        "on by default"
     )
     print("  --target_variables TARGET_VARIABLES")
     print(
@@ -564,21 +560,13 @@ def main():
     parser.add_argument(
         "--gnn_readout",
         type=str,
-        choices=["flatten", "mean", "sum", "max", "meanmax"],
-        default="flatten",
+        choices=["mean", "sum", "max", "meanmax", "attention", "dim_attention"],
+        default="dim_attention",
         help="How the GNN reduces per-node embeddings to one vector per sample. "
-        "'flatten' concatenates every node, which keeps a weight per node and "
-        "lets the model bypass the graph; the pooling options are "
-        "permutation-invariant, so node information must travel along edges",
-    )
-    parser.add_argument(
-        "--gnn_head",
-        type=str,
-        choices=["mlp", "linear"],
-        default="mlp",
-        help="Supervisor head on top of the GNN embedding. 'linear' is a "
-        "single layer, so the embedding must already be linearly separable "
-        "and the graph cannot be compensated for downstream",
+        "Every option reduces the node axis, so no weight is tied to a node's "
+        "index and node information has to travel along edges. 'dim_attention' "
+        "attends over each node's embedding dimensions instead, giving one "
+        "value per gene, which keeps gene identity",
     )
     parser.add_argument(
         "--gnn_no_projection",
@@ -595,13 +583,14 @@ def main():
         "across seeds to estimate its variability",
     )
     parser.add_argument(
-        "--use_edge_weights",
+        "--disable_edge_weighting",
         action="store_true",
-        help="If model_class is set to GNN, weight graph edges by the network's "
-        "scores instead of treating every edge as equal. Scores are normalised "
-        "to [0, 1], where 0 means no connection, so a graph may list a gene with "
-        "only zero-weight edges to keep it as an isolated node. Ignored by SAGE, "
-        "which cannot use edge weights.",
+        help="Ignore the network's edge scores and treat every edge as equal. "
+        "Weighting is on by default: scores are normalised to [0, 1], where 0 "
+        "means no connection, so a graph may list a gene with only zero-weight "
+        "edges to keep it as an isolated node. A network with no score column "
+        "is unweighted either way. Ignored by SAGE, which cannot use edge "
+        "weights.",
     )
     parser.add_argument(
         "--target_variables",
@@ -1375,9 +1364,8 @@ def main():
             early_stop_patience=int(args.early_stop_patience),
             device_type=device_type,
             gnn_conv_type=gnn_conv_type,
-            use_edge_weights=args.use_edge_weights,
+            use_edge_weights=not args.disable_edge_weighting,
             gnn_readout=args.gnn_readout,
-            gnn_head=args.gnn_head,
             gnn_project=not args.gnn_no_projection,
             input_layers=input_layers,
             output_layers=output_layers,

--- a/flexynesis/__main__.py
+++ b/flexynesis/__main__.py
@@ -1418,7 +1418,7 @@ def main():
                 # something else
                 raise TypeError(
                     "train_dataset samples stored not as List but as "
-                    f"{type(test_dataset.samples) = }"
+                    f"{type(test_dataset.samples)}"
                 )
 
         holdout_indices = list(set(all_indices) - set(finetune_indices))

--- a/flexynesis/config.py
+++ b/flexynesis/config.py
@@ -46,6 +46,10 @@ search_spaces = {
         Integer(1, 4, name="num_convs"),  # number of convolutional layers
         Real(0.0001, 0.01, prior="log-uniform", name="lr"),
         Integer(8, 32, name="supervisor_hidden_dim"),
+        # Fraction of nodes hidden for the masked-reconstruction loss.
+        # GraphMAE reports 0.5-0.75 as the useful band, but the optimum is
+        # dataset-dependent, so it is tuned rather than fixed.
+        Real(0.1, 0.7, name="gnn_mask_ratio"),
         Categorical(epochs, name="epochs"),
         Categorical(["relu"], name="activation"),
     ],

--- a/flexynesis/data.py
+++ b/flexynesis/data.py
@@ -1,6 +1,5 @@
 import os
 import tempfile
-import warnings
 from functools import reduce
 from itertools import chain
 from pathlib import Path

--- a/flexynesis/data.py
+++ b/flexynesis/data.py
@@ -1201,7 +1201,9 @@ class MultiOmicDatasetNW(Dataset):
         without that, a gene absent from the network is dropped by
         `find_union_features` instead of being kept as an isolated node.
 
-        Negative scores are shifted up by the minimum rather than clipped, so a
+        Rows with a score of exactly 0 are not edges at all; they only serve to
+        keep the gene as a node. Negative scores are shifted up by the minimum
+        rather than clipped, so a
         coexpression network keeps the ordering of its anti-correlations: the
         most negative edge becomes 0 and zero correlation lands mid-scale.
         Scores above 1 are divided by the maximum, so STRING's native 0-1000
@@ -1216,6 +1218,15 @@ class MultiOmicDatasetNW(Dataset):
             (self.interaction_df["protein1"].isin(self.common_features))
             & (self.interaction_df["protein2"].isin(self.common_features))
         ]
+
+        # A score of exactly 0 means "no connection", so it must not become an
+        # edge -- relying on a zero weight to neutralise it would turn such a
+        # network into a fully connected graph as soon as weighting is off.
+        # The row still did its job: naming the gene kept it as a node in
+        # find_union_features, which is how an unwired gene stays in the graph.
+        scores = pd.to_numeric(filtered_df["combined_score"], errors="coerce")
+        filtered_df = filtered_df[scores.notna() & (scores != 0)]
+
         edge_index = torch.tensor(
             [
                 filtered_df["protein1"].map(self.gene_to_index).tolist(),

--- a/flexynesis/data.py
+++ b/flexynesis/data.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+import warnings
 from functools import reduce
 from itertools import chain
 from pathlib import Path
@@ -1164,7 +1165,7 @@ class MultiOmicDatasetNW(Dataset):
         self.gene_to_index = {
             gene: idx for idx, gene in enumerate(self.common_features)
         }
-        self.edge_index = self.create_edge_index()
+        self.edge_index, self.edge_weight = self.create_edge_index()
         self.samples = self.multiomic_dataset.samples
         self.variable_types = self.multiomic_dataset.variable_types
         self.label_mappings = self.multiomic_dataset.label_mappings
@@ -1192,19 +1193,50 @@ class MultiOmicDatasetNW(Dataset):
         return sorted(list(all_omic_features.intersection(interaction_genes)))
 
     def create_edge_index(self):
+        """Build the COO edge index and its matching edge weights.
+
+        Weights are normalised to [0, 1], where 1 is the strongest connection
+        and 0 is no connection at all. A caller can therefore keep a gene as a
+        node while leaving it unwired, by giving it only zero-weight edges --
+        without that, a gene absent from the network is dropped by
+        `find_union_features` instead of being kept as an isolated node.
+
+        Scores above 1 are divided by the maximum, so STRING's native 0-1000
+        combined scores normalise without the caller rescaling them first.
+
+        Returns:
+            tuple: (edge_index of shape (2, n_edges), edge_weight of shape
+                (n_edges,)).
+        """
         # Create edges only if both proteins are within the available features
         filtered_df = self.interaction_df[
             (self.interaction_df["protein1"].isin(self.common_features))
             & (self.interaction_df["protein2"].isin(self.common_features))
         ]
-        edge_list = [
-            (
-                self.gene_to_index[row["protein1"]],
-                self.gene_to_index[row["protein2"]],
-            )
-            for index, row in filtered_df.iterrows()
-        ]
-        return torch.tensor(edge_list, dtype=torch.long).t()
+        edge_index = torch.tensor(
+            [
+                filtered_df["protein1"].map(self.gene_to_index).tolist(),
+                filtered_df["protein2"].map(self.gene_to_index).tolist(),
+            ],
+            dtype=torch.long,
+        )
+
+        weights = filtered_df["combined_score"].to_numpy(dtype="float32")
+        if weights.size:
+            if weights.min() < 0:
+                warnings.warn(
+                    f"Network has negative edge scores (min "
+                    f"{weights.min():.4g}); clipping them to 0. Edge weights "
+                    f"are expected in [0, 1], 0 meaning no connection."
+                )
+                weights = weights.clip(min=0)
+            if weights.max() > 1:
+                print(
+                    f"[INFO] Edge scores exceed 1 (max {weights.max():.4g}); "
+                    f"dividing by the maximum to normalise to [0, 1]."
+                )
+                weights = weights / weights.max()
+        return edge_index, torch.tensor(weights, dtype=torch.float)
 
     def precompute_node_features(self):
         num_samples = len(self.samples)
@@ -1272,11 +1304,17 @@ class MultiOmicDatasetNW(Dataset):
         num_edges = self.edge_index.size(1)
         num_node_features = self.node_features_tensor.size(2)
 
+        # A zero-weight edge means "no connection", so it must not count towards
+        # degree or a node carrying only zero-weight edges looks connected.
+        connected = self.edge_weight > 0
+        num_weighted_edges = int(connected.sum().item())
+        edge_index = self.edge_index[:, connected]
+
         # Calculate degree for each node
         degrees = torch.zeros(num_nodes, dtype=torch.long)
-        degrees.index_add_(0, self.edge_index[0], torch.ones_like(self.edge_index[0]))
+        degrees.index_add_(0, edge_index[0], torch.ones_like(edge_index[0]))
         degrees.index_add_(
-            0, self.edge_index[1], torch.ones_like(self.edge_index[1])
+            0, edge_index[1], torch.ones_like(edge_index[1])
         )  # For undirected graphs
 
         num_singletons = torch.sum(degrees == 0).item()
@@ -1293,6 +1331,8 @@ class MultiOmicDatasetNW(Dataset):
         print("Dataset Statistics:")
         print(f"Number of nodes: {num_nodes}")
         print(f"Total number of edges: {num_edges}")
+        if num_weighted_edges != num_edges:
+            print(f"Edges with a non-zero weight: {num_weighted_edges}")
         print(f"Number of node features per node: {num_node_features}")
         print(f"Number of singletons (nodes with no edges): {num_singletons}")
         print(

--- a/flexynesis/data.py
+++ b/flexynesis/data.py
@@ -1523,11 +1523,20 @@ def read_user_graph(fpath, sep=None, header="infer", **pd_read_csv_kw):
     # Read the file
     df = pd.read_csv(fpath, sep=sep, header=header, **pd_read_csv_kw)
 
-    # Validate: must have at least 3 columns
-    if df.shape[1] < 3:
+    # A network with only the two gene columns is an unweighted graph: give
+    # every edge the same score so the rest of the pipeline is unchanged, and
+    # edge weighting becomes a no-op rather than an error.
+    if df.shape[1] == 2:
+        print(
+            "[INFO] User graph has no score column; treating every edge as "
+            "equally weighted."
+        )
+        df = df.copy()
+        df["Score"] = 1.0
+    elif df.shape[1] < 2:
         raise ValueError(
-            f"User graph must have at least 3 columns (GeneA, GeneB, Score), "
-            f"but found only {df.shape[1]} columns."
+            f"User graph must have at least 2 columns (GeneA, GeneB) and "
+            f"optionally Score, but found only {df.shape[1]} column(s)."
         )
 
     # Get column names (handle cases with or without header)

--- a/flexynesis/data.py
+++ b/flexynesis/data.py
@@ -1201,6 +1201,9 @@ class MultiOmicDatasetNW(Dataset):
         without that, a gene absent from the network is dropped by
         `find_union_features` instead of being kept as an isolated node.
 
+        Negative scores are shifted up by the minimum rather than clipped, so a
+        coexpression network keeps the ordering of its anti-correlations: the
+        most negative edge becomes 0 and zero correlation lands mid-scale.
         Scores above 1 are divided by the maximum, so STRING's native 0-1000
         combined scores normalise without the caller rescaling them first.
 
@@ -1223,17 +1226,19 @@ class MultiOmicDatasetNW(Dataset):
 
         weights = filtered_df["combined_score"].to_numpy(dtype="float32")
         if weights.size:
+            shifted = False
             if weights.min() < 0:
-                warnings.warn(
-                    f"Network has negative edge scores (min "
-                    f"{weights.min():.4g}); clipping them to 0. Edge weights "
-                    f"are expected in [0, 1], 0 meaning no connection."
-                )
-                weights = weights.clip(min=0)
-            if weights.max() > 1:
                 print(
-                    f"[INFO] Edge scores exceed 1 (max {weights.max():.4g}); "
-                    f"dividing by the maximum to normalise to [0, 1]."
+                    f"[INFO] Network has negative edge scores (min "
+                    f"{weights.min():.4g}); shifting all scores up by the "
+                    f"minimum before normalising."
+                )
+                weights = weights - weights.min()
+                shifted = True
+            if (shifted or weights.max() > 1) and weights.max() > 0:
+                print(
+                    f"[INFO] Normalising edge scores to [0, 1] "
+                    f"(dividing by {weights.max():.4g})."
                 )
                 weights = weights / weights.max()
         return edge_index, torch.tensor(weights, dtype=torch.float)

--- a/flexynesis/data.py
+++ b/flexynesis/data.py
@@ -495,7 +495,11 @@ class DataImporter:
                 correlation_threshold=self.correlation_threshold,
             )
             # apply the ranked feature list to the full (unsubsampled) matrix
-            selected = log_df.loc[log_df["selected"] == True, "feature"] if "selected" in log_df.columns else log_df["feature"]
+            selected = (
+                log_df.loc[log_df["selected"].eq(True), "feature"]
+                if "selected" in log_df.columns
+                else log_df["feature"]
+            )
             dat_filtered[layer] = X[selected].T
             feature_logs[layer] = log_df
         # update main feature logs with events from this function

--- a/flexynesis/main.py
+++ b/flexynesis/main.py
@@ -95,6 +95,7 @@ class HyperparameterTuning:
         device_type=None,
         gnn_conv_type=None,
         use_edge_weights=False,
+        gnn_readout="flatten",
         input_layers=None,
         output_layers=None,
         num_workers=2,
@@ -134,6 +135,7 @@ class HyperparameterTuning:
         self.use_loss_weighting = use_loss_weighting
         self.gnn_conv_type = gnn_conv_type
         self.use_edge_weights = use_edge_weights
+        self.gnn_readout = gnn_readout
         self.input_layers = input_layers
         self.output_layers = output_layers
 
@@ -244,6 +246,7 @@ class HyperparameterTuning:
         if self.model_class.__name__ == "GNN":
             model_args["gnn_conv_type"] = self.gnn_conv_type
             model_args["use_edge_weights"] = self.use_edge_weights
+            model_args["gnn_readout"] = self.gnn_readout
         if self.model_class.__name__ == "CrossModalPred":
             model_args["input_layers"] = self.input_layers
             model_args["output_layers"] = self.output_layers

--- a/flexynesis/main.py
+++ b/flexynesis/main.py
@@ -96,6 +96,8 @@ class HyperparameterTuning:
         gnn_conv_type=None,
         use_edge_weights=False,
         gnn_readout="flatten",
+        gnn_head="mlp",
+        gnn_project=True,
         input_layers=None,
         output_layers=None,
         num_workers=2,
@@ -136,6 +138,8 @@ class HyperparameterTuning:
         self.gnn_conv_type = gnn_conv_type
         self.use_edge_weights = use_edge_weights
         self.gnn_readout = gnn_readout
+        self.gnn_head = gnn_head
+        self.gnn_project = gnn_project
         self.input_layers = input_layers
         self.output_layers = output_layers
 
@@ -247,6 +251,8 @@ class HyperparameterTuning:
             model_args["gnn_conv_type"] = self.gnn_conv_type
             model_args["use_edge_weights"] = self.use_edge_weights
             model_args["gnn_readout"] = self.gnn_readout
+            model_args["gnn_head"] = self.gnn_head
+            model_args["gnn_project"] = self.gnn_project
         if self.model_class.__name__ == "CrossModalPred":
             model_args["input_layers"] = self.input_layers
             model_args["output_layers"] = self.output_layers

--- a/flexynesis/main.py
+++ b/flexynesis/main.py
@@ -47,6 +47,7 @@ class HyperparameterTuning:
         early_stop_patience: Number of epochs with no improvement after which training will be stopped early.
         device_type: Type of device ('gpu' or 'cpu') to be used for training.
         gnn_conv_type: Specific convolution type if using Graph Neural Networks, otherwise None.
+        use_edge_weights: Whether the GNN should weight edges by the network's scores.
         input_layers: Specific input layers for models that require detailed layer setup.
         output_layers: Specific output layers for models that require detailed layer setup.
 
@@ -93,6 +94,7 @@ class HyperparameterTuning:
         early_stop_patience=-1,
         device_type=None,
         gnn_conv_type=None,
+        use_edge_weights=False,
         input_layers=None,
         output_layers=None,
         num_workers=2,
@@ -131,6 +133,7 @@ class HyperparameterTuning:
         self.early_stop_patience = early_stop_patience
         self.use_loss_weighting = use_loss_weighting
         self.gnn_conv_type = gnn_conv_type
+        self.use_edge_weights = use_edge_weights
         self.input_layers = input_layers
         self.output_layers = output_layers
 
@@ -240,6 +243,7 @@ class HyperparameterTuning:
 
         if self.model_class.__name__ == "GNN":
             model_args["gnn_conv_type"] = self.gnn_conv_type
+            model_args["use_edge_weights"] = self.use_edge_weights
         if self.model_class.__name__ == "CrossModalPred":
             model_args["input_layers"] = self.input_layers
             model_args["output_layers"] = self.output_layers

--- a/flexynesis/main.py
+++ b/flexynesis/main.py
@@ -97,7 +97,6 @@ class HyperparameterTuning:
         gnn_conv_type=None,
         use_edge_weights=True,
         gnn_readout="dim_attention",
-        gnn_project=True,
         input_layers=None,
         output_layers=None,
         num_workers=2,
@@ -138,7 +137,6 @@ class HyperparameterTuning:
         self.gnn_conv_type = gnn_conv_type
         self.use_edge_weights = use_edge_weights
         self.gnn_readout = gnn_readout
-        self.gnn_project = gnn_project
         self.input_layers = input_layers
         self.output_layers = output_layers
 
@@ -250,7 +248,6 @@ class HyperparameterTuning:
             model_args["gnn_conv_type"] = self.gnn_conv_type
             model_args["use_edge_weights"] = self.use_edge_weights
             model_args["gnn_readout"] = self.gnn_readout
-            model_args["gnn_project"] = self.gnn_project
         if self.model_class.__name__ == "CrossModalPred":
             model_args["input_layers"] = self.input_layers
             model_args["output_layers"] = self.output_layers

--- a/flexynesis/main.py
+++ b/flexynesis/main.py
@@ -47,7 +47,8 @@ class HyperparameterTuning:
         early_stop_patience: Number of epochs with no improvement after which training will be stopped early.
         device_type: Type of device ('gpu' or 'cpu') to be used for training.
         gnn_conv_type: Specific convolution type if using Graph Neural Networks, otherwise None.
-        use_edge_weights: Whether the GNN should weight edges by the network's scores.
+        use_edge_weights: Whether the GNN should weight edges by the network's
+            scores. On by default.
         input_layers: Specific input layers for models that require detailed layer setup.
         output_layers: Specific output layers for models that require detailed layer setup.
 
@@ -94,9 +95,8 @@ class HyperparameterTuning:
         early_stop_patience=-1,
         device_type=None,
         gnn_conv_type=None,
-        use_edge_weights=False,
-        gnn_readout="flatten",
-        gnn_head="mlp",
+        use_edge_weights=True,
+        gnn_readout="dim_attention",
         gnn_project=True,
         input_layers=None,
         output_layers=None,
@@ -138,7 +138,6 @@ class HyperparameterTuning:
         self.gnn_conv_type = gnn_conv_type
         self.use_edge_weights = use_edge_weights
         self.gnn_readout = gnn_readout
-        self.gnn_head = gnn_head
         self.gnn_project = gnn_project
         self.input_layers = input_layers
         self.output_layers = output_layers
@@ -251,7 +250,6 @@ class HyperparameterTuning:
             model_args["gnn_conv_type"] = self.gnn_conv_type
             model_args["use_edge_weights"] = self.use_edge_weights
             model_args["gnn_readout"] = self.gnn_readout
-            model_args["gnn_head"] = self.gnn_head
             model_args["gnn_project"] = self.gnn_project
         if self.model_class.__name__ == "CrossModalPred":
             model_args["input_layers"] = self.input_layers

--- a/flexynesis/models/crossmodal_pred.py
+++ b/flexynesis/models/crossmodal_pred.py
@@ -2,13 +2,13 @@ import itertools
 
 import lightning as pl
 import numpy as np
-from tqdm import tqdm
 import pandas as pd
 import torch
 from captum.attr import GradientShap, IntegratedGradients
 from torch import nn
 from torch.nn import functional as F
 from torch.utils.data import DataLoader
+from tqdm import tqdm
 
 from ..modules import MLP, Decoder, Encoder, cox_ph_loss
 

--- a/flexynesis/models/direct_pred.py
+++ b/flexynesis/models/direct_pred.py
@@ -1,12 +1,12 @@
 import lightning as pl
 import numpy as np
-from tqdm import tqdm
 import pandas as pd
 import torch
 from captum.attr import GradientShap, IntegratedGradients
 from torch import nn
 from torch.nn import functional as F
 from torch.utils.data import DataLoader
+from tqdm import tqdm
 
 from ..modules import MLP, cox_ph_loss
 from ..utils import to_device_safe

--- a/flexynesis/models/gnn_early.py
+++ b/flexynesis/models/gnn_early.py
@@ -65,6 +65,8 @@ class GNN(pl.LightningModule):
         gnn_conv_type=None,
         use_edge_weights=False,
         gnn_readout="flatten",
+        gnn_head="mlp",
+        gnn_project=True,
     ):
         super().__init__()
         self.config = config
@@ -101,6 +103,8 @@ class GNN(pl.LightningModule):
         self.device_type = device_type
         self.gnn_conv_type = gnn_conv_type
         self.gnn_readout = gnn_readout
+        self.gnn_head = gnn_head
+        self.gnn_project = gnn_project
 
         from ..utils import create_device_from_string
 
@@ -132,10 +136,11 @@ class GNN(pl.LightningModule):
                     num_convs=int(
                         self.config["num_convs"]
                     ),  # Number of convolutional layers
-                    output_dim=self.config["latent_dim"],
+                    output_dim=int(self.config["latent_dim"]),
                     act=self.config["activation"],
                     conv=self.gnn_conv_type,
                     readout=self.gnn_readout,
+                    project=self.gnn_project,
                 )
             ]
         )
@@ -147,11 +152,18 @@ class GNN(pl.LightningModule):
                 num_class = 1
             else:
                 num_class = len(np.unique(self.ann[var]))
-            self.MLPs[var] = MLP(
-                input_dim=self.config["latent_dim"],
-                hidden_dim=self.config["supervisor_hidden_dim"],
-                output_dim=num_class,
-            )
+            # A linear head cannot reshape a weak representation into a good
+            # prediction, so whatever separates the classes has to already be
+            # there when the graph is done with it.
+            embedding_dim = self.encoders[0].output_dim
+            if self.gnn_head == "linear":
+                self.MLPs[var] = nn.Linear(embedding_dim, num_class)
+            else:
+                self.MLPs[var] = MLP(
+                    input_dim=embedding_dim,
+                    hidden_dim=int(self.config["supervisor_hidden_dim"]),
+                    output_dim=num_class,
+                )
 
     def _dataset_edge_weight(self, dataset, device):
         """Edge weights for a dataset, or None when weighting is disabled."""

--- a/flexynesis/models/gnn_early.py
+++ b/flexynesis/models/gnn_early.py
@@ -2,13 +2,13 @@ import itertools
 
 import lightning as pl
 import numpy as np
-from tqdm import tqdm
 import pandas as pd
 import torch
 from captum.attr import GradientShap, IntegratedGradients
 from torch import nn
 from torch.nn import functional as F
 from torch.utils.data import DataLoader
+from tqdm import tqdm
 
 from ..modules import MLP, GraphMAEHead, cox_ph_loss, flexGCN
 from ..utils import to_device_safe

--- a/flexynesis/models/gnn_early.py
+++ b/flexynesis/models/gnn_early.py
@@ -64,6 +64,7 @@ class GNN(pl.LightningModule):
         device_type=None,
         gnn_conv_type=None,
         use_edge_weights=False,
+        gnn_readout="flatten",
     ):
         super().__init__()
         self.config = config
@@ -99,6 +100,7 @@ class GNN(pl.LightningModule):
 
         self.device_type = device_type
         self.gnn_conv_type = gnn_conv_type
+        self.gnn_readout = gnn_readout
 
         from ..utils import create_device_from_string
 
@@ -133,6 +135,7 @@ class GNN(pl.LightningModule):
                     output_dim=self.config["latent_dim"],
                     act=self.config["activation"],
                     conv=self.gnn_conv_type,
+                    readout=self.gnn_readout,
                 )
             ]
         )

--- a/flexynesis/models/gnn_early.py
+++ b/flexynesis/models/gnn_early.py
@@ -63,9 +63,8 @@ class GNN(pl.LightningModule):
         use_loss_weighting=True,
         device_type=None,
         gnn_conv_type=None,
-        use_edge_weights=False,
-        gnn_readout="flatten",
-        gnn_head="mlp",
+        use_edge_weights=True,
+        gnn_readout="dim_attention",
         gnn_project=True,
     ):
         super().__init__()
@@ -89,9 +88,8 @@ class GNN(pl.LightningModule):
         self.ann = getattr(dataset, "multiomic_dataset", dataset).ann
         self.edge_index = dataset.edge_index
         # Zero-weight edges encode "no connection", which is what lets a graph
-        # keep an unwired gene as a node instead of dropping it. That only
-        # holds if the weights are actually used, so without this flag such a
-        # graph would be read as fully connected.
+        # keep an unwired gene as a node instead of dropping it. Weighting is on
+        # by default; turning it off reads such a graph as fully connected.
         self.use_edge_weights = use_edge_weights
         self.edge_weight = (
             getattr(dataset, "edge_weight", None) if use_edge_weights else None
@@ -103,7 +101,6 @@ class GNN(pl.LightningModule):
         self.device_type = device_type
         self.gnn_conv_type = gnn_conv_type
         self.gnn_readout = gnn_readout
-        self.gnn_head = gnn_head
         self.gnn_project = gnn_project
 
         from ..utils import create_device_from_string
@@ -152,18 +149,11 @@ class GNN(pl.LightningModule):
                 num_class = 1
             else:
                 num_class = len(np.unique(self.ann[var]))
-            # A linear head cannot reshape a weak representation into a good
-            # prediction, so whatever separates the classes has to already be
-            # there when the graph is done with it.
-            embedding_dim = self.encoders[0].output_dim
-            if self.gnn_head == "linear":
-                self.MLPs[var] = nn.Linear(embedding_dim, num_class)
-            else:
-                self.MLPs[var] = MLP(
-                    input_dim=embedding_dim,
-                    hidden_dim=int(self.config["supervisor_hidden_dim"]),
-                    output_dim=num_class,
-                )
+            self.MLPs[var] = MLP(
+                input_dim=self.encoders[0].output_dim,
+                hidden_dim=int(self.config["supervisor_hidden_dim"]),
+                output_dim=num_class,
+            )
 
     def _dataset_edge_weight(self, dataset, device):
         """Edge weights for a dataset, or None when weighting is disabled."""

--- a/flexynesis/models/gnn_early.py
+++ b/flexynesis/models/gnn_early.py
@@ -1,3 +1,5 @@
+import itertools
+
 import lightning as pl
 import numpy as np
 from tqdm import tqdm
@@ -8,7 +10,7 @@ from torch import nn
 from torch.nn import functional as F
 from torch.utils.data import DataLoader
 
-from ..modules import MLP, cox_ph_loss, flexGCN
+from ..modules import MLP, GraphMAEHead, cox_ph_loss, flexGCN
 from ..utils import to_device_safe
 
 
@@ -65,7 +67,6 @@ class GNN(pl.LightningModule):
         gnn_conv_type=None,
         use_edge_weights=True,
         gnn_readout="dim_attention",
-        gnn_project=True,
     ):
         super().__init__()
         self.config = config
@@ -101,7 +102,6 @@ class GNN(pl.LightningModule):
         self.device_type = device_type
         self.gnn_conv_type = gnn_conv_type
         self.gnn_readout = gnn_readout
-        self.gnn_project = gnn_project
 
         from ..utils import create_device_from_string
 
@@ -116,11 +116,19 @@ class GNN(pl.LightningModule):
         if self.edge_weight is not None:
             self.edge_weight = to_device_safe(self.edge_weight, device)
 
+        # The mask ratio is an ordinary hyperparameter drawn from the search
+        # space; `.get` keeps configs that predate it working at GraphMAE's
+        # default. Pinning it to 0 disables the auxiliary loss, in which case
+        # no log-variance is registered for it below.
+        self.mask_ratio = float(self.config.get("gnn_mask_ratio", 0.5))
+        self.use_mae = self.mask_ratio > 0
+
         if self.use_loss_weighting:
             # Initialize log variance parameters for uncertainty weighting
             self.log_vars = nn.ParameterDict()
-            for var in self.variables:
-                self.log_vars[var] = nn.Parameter(torch.zeros(1))
+            aux = ["recon_loss"] if self.use_mae else []
+            for loss_type in itertools.chain(self.variables, aux):
+                self.log_vars[loss_type] = nn.Parameter(torch.zeros(1))
 
         self.encoders = nn.ModuleList(
             [
@@ -137,7 +145,6 @@ class GNN(pl.LightningModule):
                     act=self.config["activation"],
                     conv=self.gnn_conv_type,
                     readout=self.gnn_readout,
-                    project=self.gnn_project,
                 )
             ]
         )
@@ -154,6 +161,21 @@ class GNN(pl.LightningModule):
                 hidden_dim=int(self.config["supervisor_hidden_dim"]),
                 output_dim=num_class,
             )
+
+        # Auxiliary masked-feature reconstruction head.
+        self.mae = (
+            GraphMAEHead(
+                node_feature_count=dataset[0][0].shape[1],
+                node_embedding_dim=int(self.config["node_embedding_dim"]),
+                mask_ratio=self.mask_ratio,
+                # resolved from the input: the scaled cosine error needs more
+                # than one feature per node to be meaningful
+                loss="auto",
+                conv=self.gnn_conv_type,
+            )
+            if self.use_mae
+            else None
+        )
 
     def _dataset_edge_weight(self, dataset, device):
         """Edge weights for a dataset, or None when weighting is disabled."""
@@ -181,6 +203,28 @@ class GNN(pl.LightningModule):
             outputs[var] = mlp(embeddings)
         return outputs
 
+    def masked_recon_loss(self, x):
+        """GraphMAE auxiliary loss: rebuild masked node values from neighbours.
+
+        This runs a second encoder pass on the masked input, so the supervised
+        head still sees the clean signal and the two objectives do not
+        interfere through the input.
+        """
+        # Validation uses a fixed mask, otherwise a stochastic term rides on
+        # val_loss and adds noise to the early-stopping decision.
+        generator = None
+        if not self.training:
+            generator = torch.Generator(device=x.device)
+            generator.manual_seed(0)
+        x_masked, mask = self.mae.apply_mask(x, generator=generator)
+        nodes = self.encoders[0].encode_nodes(
+            x_masked, self.edge_index, self.edge_weight
+        )
+        x_hat = self.mae.reconstruct(
+            nodes, self.edge_index, mask, self.edge_weight
+        )
+        return self.mae.loss(x, x_hat, mask)
+
     def training_step(self, batch, batch_idx, log=True):
         """
         Performs a training step including loss calculation and logging.
@@ -195,7 +239,7 @@ class GNN(pl.LightningModule):
         x, y_dict, samples = batch
         outputs = self.forward(x, self.edge_index, self.edge_weight)
 
-        losses = {}
+        losses = {"recon_loss": self.masked_recon_loss(x)} if self.mae else {}
         for var in self.variables:
             if var == self.surv_event_var:
                 durations = y_dict[self.surv_time_var]
@@ -233,7 +277,7 @@ class GNN(pl.LightningModule):
         """
         x, y_dict, samples = batch
         outputs = self.forward(x, self.edge_index, self.edge_weight)
-        losses = {}
+        losses = {"recon_loss": self.masked_recon_loss(x)} if self.mae else {}
         for var in self.variables:
             if var == self.surv_event_var:
                 durations = y_dict[self.surv_time_var]

--- a/flexynesis/models/gnn_early.py
+++ b/flexynesis/models/gnn_early.py
@@ -63,6 +63,7 @@ class GNN(pl.LightningModule):
         use_loss_weighting=True,
         device_type=None,
         gnn_conv_type=None,
+        use_edge_weights=False,
     ):
         super().__init__()
         self.config = config
@@ -84,6 +85,14 @@ class GNN(pl.LightningModule):
         ).variable_types
         self.ann = getattr(dataset, "multiomic_dataset", dataset).ann
         self.edge_index = dataset.edge_index
+        # Zero-weight edges encode "no connection", which is what lets a graph
+        # keep an unwired gene as a node instead of dropping it. That only
+        # holds if the weights are actually used, so without this flag such a
+        # graph would be read as fully connected.
+        self.use_edge_weights = use_edge_weights
+        self.edge_weight = (
+            getattr(dataset, "edge_weight", None) if use_edge_weights else None
+        )
 
         self.feature_importances = {}
         self.use_loss_weighting = use_loss_weighting
@@ -101,6 +110,8 @@ class GNN(pl.LightningModule):
         self.edge_index = to_device_safe(
             self.edge_index, device
         )  # edge index is re-used across samples, so we keep it in device
+        if self.edge_weight is not None:
+            self.edge_weight = to_device_safe(self.edge_weight, device)
 
         if self.use_loss_weighting:
             # Initialize log variance parameters for uncertainty weighting
@@ -139,19 +150,27 @@ class GNN(pl.LightningModule):
                 output_dim=num_class,
             )
 
-    def forward(self, x, edge_index):
+    def _dataset_edge_weight(self, dataset, device):
+        """Edge weights for a dataset, or None when weighting is disabled."""
+        if not self.use_edge_weights:
+            return None
+        weights = getattr(dataset, "edge_weight", None)
+        return None if weights is None else weights.to(device)
+
+    def forward(self, x, edge_index, edge_weight=None):
         """
         Defines the forward pass of the GNN.
 
         Args:
             x (Tensor): Node feature matrix (batch_size, num_nodes, node_feature_count).
             edge_index (Tensor): Edge index in COO format (2, num_edges).
+            edge_weight (Tensor, optional): Per-edge weights in [0, 1].
 
         Returns:
             dict: Outputs from the MLPs, one for each target variable.
         """
         # notice we are using the first encoder (it is currently a early fusion method)
-        embeddings = self.encoders[0](x, edge_index)
+        embeddings = self.encoders[0](x, edge_index, edge_weight)
         outputs = {}
         for var, mlp in self.MLPs.items():
             outputs[var] = mlp(embeddings)
@@ -169,7 +188,7 @@ class GNN(pl.LightningModule):
             float: Total loss for the batch.
         """
         x, y_dict, samples = batch
-        outputs = self.forward(x, self.edge_index)
+        outputs = self.forward(x, self.edge_index, self.edge_weight)
 
         losses = {}
         for var in self.variables:
@@ -208,7 +227,7 @@ class GNN(pl.LightningModule):
             float: Total validation loss for the batch.
         """
         x, y_dict, samples = batch
-        outputs = self.forward(x, self.edge_index)
+        outputs = self.forward(x, self.edge_index, self.edge_weight)
         losses = {}
         for var in self.variables:
             if var == self.surv_event_var:
@@ -348,6 +367,7 @@ class GNN(pl.LightningModule):
             dataset, batch_size=64, shuffle=False
         )  # Adjust the batch size as needed
         edge_index = dataset.edge_index.to(device)  # Move edge_index to GPU
+        edge_weight = self._dataset_edge_weight(dataset, device)
 
         predictions = {
             var: [] for var in self.variables
@@ -357,7 +377,7 @@ class GNN(pl.LightningModule):
         for x, y_dict, samples in dataloader:
             x = x.to(device)  # Move data to GPU
 
-            outputs = self.forward(x, edge_index)
+            outputs = self.forward(x, edge_index, edge_weight)
             for var in self.variables:
                 logits = outputs[var].detach().cpu()  # Raw model outputs (logits)
 
@@ -395,6 +415,7 @@ class GNN(pl.LightningModule):
         )
         self.to(device)  # Move the model to the appropriate device
         edge_index = dataset.edge_index.to(device)  # Move edge_index to GPU
+        edge_weight = self._dataset_edge_weight(dataset, device)
 
         dataloader = DataLoader(
             dataset, batch_size=64, shuffle=False
@@ -408,7 +429,10 @@ class GNN(pl.LightningModule):
 
             # notice we are using the first encoder (it is currently a early fusion method)
             embeddings = (
-                self.encoders[0](x, edge_index).detach().cpu().numpy()
+                self.encoders[0](x, edge_index, edge_weight)
+                .detach()
+                .cpu()
+                .numpy()
             )  # Compute embeddings and move to CPU
             all_embeddings.append(embeddings)
             sample_ids.extend(samples)
@@ -433,7 +457,9 @@ class GNN(pl.LightningModule):
         for i in range(steps):
             x_step = input_data[0][i]
             # edges_step = edge_index[i] # although, identical, they get copied.
-            out = self.forward(x_step, self.dataset_edge_index)
+            out = self.forward(
+                x_step, self.dataset_edge_index, self.dataset_edge_weight
+            )
             outputs_list.append(out[target_var])
         return torch.cat(outputs_list, dim=0)
 
@@ -482,6 +508,7 @@ class GNN(pl.LightningModule):
 
         self.to(device)
         self.dataset_edge_index = to_device_safe(dataset.edge_index, device)
+        self.dataset_edge_weight = self._dataset_edge_weight(dataset, device)
 
         dataloader = DataLoader(dataset, batch_size=batch_size, shuffle=False)
 

--- a/flexynesis/models/supervised_vae.py
+++ b/flexynesis/models/supervised_vae.py
@@ -3,13 +3,13 @@ import itertools
 
 import lightning as pl
 import numpy as np
-from tqdm import tqdm
 import pandas as pd
 import torch
 from captum.attr import GradientShap, IntegratedGradients
 from torch import nn
 from torch.nn import functional as F
 from torch.utils.data import DataLoader
+from tqdm import tqdm
 
 from ..modules import MLP, Decoder, Encoder, cox_ph_loss
 

--- a/flexynesis/models/triplet_encoder.py
+++ b/flexynesis/models/triplet_encoder.py
@@ -3,13 +3,13 @@ import itertools
 
 import lightning as pl
 import numpy as np
-from tqdm import tqdm
 import pandas as pd
 import torch
 from captum.attr import GradientShap, IntegratedGradients
 from torch import nn
 from torch.nn import functional as F
 from torch.utils.data import DataLoader
+from tqdm import tqdm
 
 from ..data import TripletMultiOmicDataset
 from ..modules import MLP, cox_ph_loss

--- a/flexynesis/modules.py
+++ b/flexynesis/modules.py
@@ -1,6 +1,7 @@
 # Networks that can be reused across different architectures
 
 import warnings
+
 import torch
 from torch import nn
 from torch.nn import functional as F

--- a/flexynesis/modules.py
+++ b/flexynesis/modules.py
@@ -1,5 +1,6 @@
 # Networks that can be reused across different architectures
 
+import warnings
 import torch
 from torch import nn
 from torch_geometric.nn import GATConv, GCNConv, GraphConv, SAGEConv
@@ -231,6 +232,9 @@ class flexGCN(nn.Module):
             )
 
         self.act = act_options[act]
+        # SAGEConv aggregates over neighbours with no slot for a scalar weight,
+        # and GATConv learns its own attention, so only these two can take one.
+        self.supports_edge_weight = conv in ("GCN", "GC")
         self.convs = nn.ModuleList()
         self.bns = nn.ModuleList()
         self.dropout = nn.Dropout(dropout_rate)
@@ -249,9 +253,18 @@ class flexGCN(nn.Module):
         # Final fully connected layer
         self.fc = nn.Linear(node_embedding_dim * node_count, output_dim)
 
-    def forward(self, x, edge_index):
+    def forward(self, x, edge_index, edge_weight=None):
+        if edge_weight is not None and not self.supports_edge_weight:
+            warnings.warn(
+                "Edge weights were provided but this convolution type ignores "
+                "them; use GCN or GC to make use of them."
+            )
+            edge_weight = None
         for conv, bn in zip(self.convs, self.bns):
-            x = conv(x, edge_index)
+            if edge_weight is None:
+                x = conv(x, edge_index)
+            else:
+                x = conv(x, edge_index, edge_weight)
             x = bn(x.view(-1, x.size(2))).view_as(x)
             x = self.act(x)
             x = self.dropout(x)

--- a/flexynesis/modules.py
+++ b/flexynesis/modules.py
@@ -203,6 +203,7 @@ class flexGCN(nn.Module):
         dropout_rate=0.2,
         conv="GC",
         act="relu",
+        readout="flatten",
     ):
         super().__init__()
 
@@ -250,8 +251,24 @@ class flexGCN(nn.Module):
             )
             self.bns.append(nn.BatchNorm1d(node_embedding_dim))
 
-        # Final fully connected layer
-        self.fc = nn.Linear(node_embedding_dim * node_count, output_dim)
+        readout_options = ("flatten", "mean", "sum", "max", "meanmax")
+        if readout not in readout_options:
+            raise ValueError(
+                "Unknown readout. Choose one of: ", list(readout_options)
+            )
+        self.readout = readout
+
+        # Final fully connected layer. "flatten" keeps one weight per (node,
+        # channel) pair, which lets the model read any node directly and makes
+        # the graph optional; the pooling readouts are permutation-invariant, so
+        # a node's contribution has to arrive through message passing.
+        if readout == "flatten":
+            fc_in = node_embedding_dim * node_count
+        elif readout == "meanmax":
+            fc_in = node_embedding_dim * 2
+        else:
+            fc_in = node_embedding_dim
+        self.fc = nn.Linear(fc_in, output_dim)
 
     def forward(self, x, edge_index, edge_weight=None):
         if edge_weight is not None and not self.supports_edge_weight:
@@ -269,8 +286,17 @@ class flexGCN(nn.Module):
             x = self.act(x)
             x = self.dropout(x)
 
-        # Flatten the output of all nodes into a single vector per graph/sample
-        x = x.view(x.size(0), -1)
+        # Reduce the per-node embeddings to one vector per graph/sample
+        if self.readout == "flatten":
+            x = x.view(x.size(0), -1)
+        elif self.readout == "mean":
+            x = x.mean(dim=1)
+        elif self.readout == "sum":
+            x = x.sum(dim=1)
+        elif self.readout == "max":
+            x = x.max(dim=1).values
+        else:  # meanmax
+            x = torch.cat([x.mean(dim=1), x.max(dim=1).values], dim=1)
         x = self.fc(x)
         return x
 

--- a/flexynesis/modules.py
+++ b/flexynesis/modules.py
@@ -204,6 +204,7 @@ class flexGCN(nn.Module):
         conv="GC",
         act="relu",
         readout="flatten",
+        project=True,
     ):
         super().__init__()
 
@@ -268,7 +269,17 @@ class flexGCN(nn.Module):
             fc_in = node_embedding_dim * 2
         else:
             fc_in = node_embedding_dim
-        self.fc = nn.Linear(fc_in, output_dim)
+
+        # With project=False the pooled node embeddings *are* the sample
+        # representation, instead of being re-projected into a wider latent
+        # space. That keeps the representation a direct combination of node
+        # embeddings, so it can only be as good as the graph made them.
+        if project:
+            self.fc = nn.Linear(fc_in, output_dim)
+            self.output_dim = output_dim
+        else:
+            self.fc = nn.Identity()
+            self.output_dim = fc_in
 
     def forward(self, x, edge_index, edge_weight=None):
         if edge_weight is not None and not self.supports_edge_weight:

--- a/flexynesis/modules.py
+++ b/flexynesis/modules.py
@@ -203,7 +203,7 @@ class flexGCN(nn.Module):
         dropout_rate=0.2,
         conv="GC",
         act="relu",
-        readout="flatten",
+        readout="dim_attention",
         project=True,
     ):
         super().__init__()
@@ -252,23 +252,47 @@ class flexGCN(nn.Module):
             )
             self.bns.append(nn.BatchNorm1d(node_embedding_dim))
 
-        readout_options = ("flatten", "mean", "sum", "max", "meanmax")
+        readout_options = ("mean", "sum", "max", "meanmax", "attention",
+                           "dim_attention")
         if readout not in readout_options:
             raise ValueError(
                 "Unknown readout. Choose one of: ", list(readout_options)
             )
         self.readout = readout
 
-        # Final fully connected layer. "flatten" keeps one weight per (node,
-        # channel) pair, which lets the model read any node directly and makes
-        # the graph optional; the pooling readouts are permutation-invariant, so
-        # a node's contribution has to arrive through message passing.
-        if readout == "flatten":
-            fc_in = node_embedding_dim * node_count
-        elif readout == "meanmax":
+        # Final fully connected layer. Every readout here reduces the node
+        # axis, so no weight is tied to a node's index: a readout that keeps one
+        # weight per (node, channel) pair lets the model read any node directly
+        # and makes the graph optional, which is why none is offered.
+        if readout == "meanmax":
             fc_in = node_embedding_dim * 2
+        elif readout == "dim_attention":
+            fc_in = node_count
         else:
             fc_in = node_embedding_dim
+
+        # Attention pooling scores each node from its own embedding, never from
+        # its index, so the pooling stays permutation-equivariant: relabel the
+        # nodes and the sample vector is unchanged. It can still emphasise
+        # informative nodes, which plain mean pooling cannot -- and because the
+        # embeddings come out of message passing, which nodes look worth
+        # attending to is decided by the graph.
+        self.attention = (
+            nn.Linear(node_embedding_dim, 1) if readout == "attention" else None
+        )
+
+        # "dim_attention" attends over the embedding *dimensions* of each node
+        # rather than over the nodes, collapsing every node to one number and
+        # concatenating those, so the sample vector is one value per gene.
+        # Gene identity survives as position, which node pooling throws away,
+        # at 1/node_embedding_dim of the width of a per-node readout. The scores come from the
+        # node's own embedding and the layer is shared across nodes, so which
+        # dimension wins can differ per gene without a per-gene parameter.
+        self.dim_attention = (
+            nn.Linear(node_embedding_dim, node_embedding_dim)
+            if readout == "dim_attention" else None
+        )
+        self.last_attention = None
 
         # With project=False the pooled node embeddings *are* the sample
         # representation, instead of being re-projected into a wider latent
@@ -298,14 +322,21 @@ class flexGCN(nn.Module):
             x = self.dropout(x)
 
         # Reduce the per-node embeddings to one vector per graph/sample
-        if self.readout == "flatten":
-            x = x.view(x.size(0), -1)
-        elif self.readout == "mean":
+        if self.readout == "mean":
             x = x.mean(dim=1)
         elif self.readout == "sum":
             x = x.sum(dim=1)
         elif self.readout == "max":
             x = x.max(dim=1).values
+        elif self.readout == "attention":
+            weights = torch.softmax(self.attention(x), dim=1)
+            self.last_attention = weights.detach()
+            x = (weights * x).sum(dim=1)
+        elif self.readout == "dim_attention":
+            # softmax over dim=2: the embedding dimensions of each node
+            weights = torch.softmax(self.dim_attention(x), dim=2)
+            self.last_attention = weights.detach()
+            x = (weights * x).sum(dim=2)
         else:  # meanmax
             x = torch.cat([x.mean(dim=1), x.max(dim=1).values], dim=1)
         x = self.fc(x)

--- a/flexynesis/modules.py
+++ b/flexynesis/modules.py
@@ -3,9 +3,20 @@
 import warnings
 import torch
 from torch import nn
+from torch.nn import functional as F
 from torch_geometric.nn import GATConv, GCNConv, GraphConv, SAGEConv
 
-__all__ = ["Encoder", "Decoder", "MLP", "flexGCN", "cox_ph_loss"]
+__all__ = ["Encoder", "Decoder", "MLP", "flexGCN", "GraphMAEHead", "cox_ph_loss"]
+
+CONV_OPTIONS = {
+    "GCN": GCNConv,
+    "GAT": GATConv,
+    "SAGE": SAGEConv,
+    "GC": GraphConv,
+}
+# SAGEConv aggregates over neighbours with no slot for a scalar weight, and
+# GATConv learns its own attention, so only these two can take an edge weight.
+EDGE_WEIGHTED_CONVS = ("GCN", "GC")
 
 
 class Encoder(nn.Module):
@@ -204,7 +215,7 @@ class flexGCN(nn.Module):
         conv="GC",
         act="relu",
         readout="dim_attention",
-        project=True,
+        add_self_loops=True,
     ):
         super().__init__()
 
@@ -221,12 +232,7 @@ class flexGCN(nn.Module):
                 list(act_options.keys()),
             )
 
-        conv_options = {
-            "GCN": GCNConv,
-            "GAT": GATConv,
-            "SAGE": SAGEConv,
-            "GC": GraphConv,
-        }
+        conv_options = CONV_OPTIONS
         if conv not in conv_options:
             raise ValueError(
                 "Unknown convolution type. Choose one of: ",
@@ -234,78 +240,85 @@ class flexGCN(nn.Module):
             )
 
         self.act = act_options[act]
-        # SAGEConv aggregates over neighbours with no slot for a scalar weight,
-        # and GATConv learns its own attention, so only these two can take one.
-        self.supports_edge_weight = conv in ("GCN", "GC")
+        self.supports_edge_weight = conv in EDGE_WEIGHTED_CONVS
+
+        # GCN's renormalisation trick is defined on A + I (Kipf & Welling
+        # 2017), so self-loops are on by default. With them off, a node's
+        # representation is built purely from its neighbours and an isolated
+        # node contributes nothing. GraphConv keeps a separate root weight and
+        # SAGEConv concatenates the node's own features, so neither accepts the
+        # argument and for those two a self-connection is always present.
+        conv_kwargs = ({"add_self_loops": add_self_loops}
+                       if conv in ("GCN", "GAT") else {})
         self.convs = nn.ModuleList()
         self.bns = nn.ModuleList()
         self.dropout = nn.Dropout(dropout_rate)
 
         # Initialize the first convolution layer separately if different input size
-        self.convs.append(conv_options[conv](node_feature_count, node_embedding_dim))
+        self.convs.append(conv_options[conv](node_feature_count,
+                                             node_embedding_dim, **conv_kwargs))
         self.bns.append(nn.BatchNorm1d(node_embedding_dim))
 
         # Loop to create the remaining convolution and BN layers
         for _ in range(1, num_convs):
             self.convs.append(
-                conv_options[conv](node_embedding_dim, node_embedding_dim)
+                conv_options[conv](node_embedding_dim, node_embedding_dim,
+                                   **conv_kwargs)
             )
             self.bns.append(nn.BatchNorm1d(node_embedding_dim))
 
         readout_options = ("mean", "sum", "max", "meanmax", "attention",
-                           "dim_attention")
+                           "dim_attention", "flatten")
         if readout not in readout_options:
             raise ValueError(
                 "Unknown readout. Choose one of: ", list(readout_options)
             )
         self.readout = readout
 
-        # Final fully connected layer. Every readout here reduces the node
-        # axis, so no weight is tied to a node's index: a readout that keeps one
-        # weight per (node, channel) pair lets the model read any node directly
-        # and makes the graph optional, which is why none is offered.
+        # Width of the sample representation the final layer sees. The pooling
+        # readouts collapse the node axis entirely; "dim_attention" leaves one
+        # value per node and "flatten" leaves a node's full embedding.
         if readout == "meanmax":
             fc_in = node_embedding_dim * 2
         elif readout == "dim_attention":
             fc_in = node_count
+        elif readout == "flatten":
+            fc_in = node_count * node_embedding_dim
         else:
             fc_in = node_embedding_dim
 
-        # Attention pooling scores each node from its own embedding, never from
-        # its index, so the pooling stays permutation-equivariant: relabel the
-        # nodes and the sample vector is unchanged. It can still emphasise
-        # informative nodes, which plain mean pooling cannot -- and because the
-        # embeddings come out of message passing, which nodes look worth
-        # attending to is decided by the graph.
+        # Attention pooling scores each node from its own embedding, never
+        # from its index, so pooling stays permutation-equivariant: relabel the
+        # nodes and the sample vector is unchanged. Unlike mean pooling it can
+        # still weight informative nodes above uninformative ones.
         self.attention = (
             nn.Linear(node_embedding_dim, 1) if readout == "attention" else None
         )
 
-        # "dim_attention" attends over the embedding *dimensions* of each node
-        # rather than over the nodes, collapsing every node to one number and
-        # concatenating those, so the sample vector is one value per gene.
-        # Gene identity survives as position, which node pooling throws away,
-        # at 1/node_embedding_dim of the width of a per-node readout. The scores come from the
-        # node's own embedding and the layer is shared across nodes, so which
-        # dimension wins can differ per gene without a per-gene parameter.
+        # "dim_attention" attends over the embedding *dimensions* of each
+        # node rather than over the nodes, collapsing each node to one number
+        # and concatenating those. Node identity survives as position, which
+        # node pooling discards, at 1/node_embedding_dim of the width of
+        # "flatten". Scores come from the node's own embedding through a layer
+        # shared across nodes, so which dimension wins can differ per node
+        # without a per-node parameter.
         self.dim_attention = (
             nn.Linear(node_embedding_dim, node_embedding_dim)
             if readout == "dim_attention" else None
         )
         self.last_attention = None
 
-        # With project=False the pooled node embeddings *are* the sample
-        # representation, instead of being re-projected into a wider latent
-        # space. That keeps the representation a direct combination of node
-        # embeddings, so it can only be as good as the graph made them.
-        if project:
-            self.fc = nn.Linear(fc_in, output_dim)
-            self.output_dim = output_dim
-        else:
-            self.fc = nn.Identity()
-            self.output_dim = fc_in
+        # The readout is projected into a latent space of size output_dim,
+        # which is what the downstream heads consume.
+        self.fc = nn.Linear(fc_in, output_dim)
+        self.output_dim = output_dim
 
-    def forward(self, x, edge_index, edge_weight=None):
+    def encode_nodes(self, x, edge_index, edge_weight=None):
+        """Message passing only: returns one embedding per node, unpooled.
+
+        Kept separate from the readout so auxiliary heads that work per node
+        (e.g. GraphMAEHead) can reuse the same encoder pass.
+        """
         if edge_weight is not None and not self.supports_edge_weight:
             warnings.warn(
                 "Edge weights were provided but this convolution type ignores "
@@ -321,7 +334,10 @@ class flexGCN(nn.Module):
             x = self.act(x)
             x = self.dropout(x)
 
-        # Reduce the per-node embeddings to one vector per graph/sample
+        return x
+
+    def pool(self, x):
+        """Reduce the per-node embeddings to one vector per graph/sample."""
         if self.readout == "mean":
             x = x.mean(dim=1)
         elif self.readout == "sum":
@@ -337,10 +353,112 @@ class flexGCN(nn.Module):
             weights = torch.softmax(self.dim_attention(x), dim=2)
             self.last_attention = weights.detach()
             x = (weights * x).sum(dim=2)
+        elif self.readout == "flatten":
+            # Concatenate every node's full embedding, so the sample vector
+            # is node_count * node_embedding_dim wide and node i occupies a
+            # fixed slice. Customary when one graph is shared across samples
+            # and each sample is a signal over its nodes (Defferrard et al.
+            # 2016; Chereda et al. 2019). Unlike the pooling readouts it ties
+            # weights to node indices, which keeps node identity but costs
+            # permutation equivariance and scales with the node count.
+            x = x.reshape(x.size(0), -1)
         else:  # meanmax
             x = torch.cat([x.mean(dim=1), x.max(dim=1).values], dim=1)
         x = self.fc(x)
         return x
+
+    def forward(self, x, edge_index, edge_weight=None, return_nodes=False):
+        nodes = self.encode_nodes(x, edge_index, edge_weight)
+        pooled = self.pool(nodes)
+        return (pooled, nodes) if return_nodes else pooled
+
+
+class GraphMAEHead(nn.Module):
+    """Masked node-feature reconstruction (GraphMAE, Hou et al. 2022, KDD).
+
+    A random subset of each sample's nodes has its input value replaced by a
+    learned mask token; the encoder runs as usual; the masked nodes' embeddings
+    are then zeroed again ("re-masking") and a one-layer graph convolution has
+    to rebuild the hidden values from the neighbours alone. Used as an
+    auxiliary objective alongside a supervised head, it pushes the encoder to
+    propagate information between neighbouring nodes.
+
+    The reconstruction target is the node features, not the adjacency matrix as
+    in the Kipf & Welling graph auto-encoder. Adjacency reconstruction is
+    invariant to a relabelling of the nodes, so it cannot express whether the
+    identities attached to the nodes are the right ones.
+    """
+
+    def __init__(
+        self,
+        node_feature_count,
+        node_embedding_dim,
+        mask_ratio=0.5,
+        loss="auto",
+        gamma=2.0,
+        conv="GCN",
+    ):
+        super().__init__()
+        if not 0.0 < mask_ratio < 1.0:
+            raise ValueError("mask_ratio must be in (0, 1)")
+        if conv not in CONV_OPTIONS:
+            raise ValueError("Unknown convolution type. Choose one of: ",
+                             list(CONV_OPTIONS))
+        self.mask_ratio = mask_ratio
+        self.gamma = gamma
+
+        # GraphMAE scores reconstruction with the scaled cosine error, which
+        # compares the *direction* of a node's feature vector. The cosine of
+        # two scalars is always +-1, so that is degenerate when a node carries
+        # a single feature (one omics layer); fall back to MSE there.
+        if loss == "auto":
+            loss = "sce" if node_feature_count > 1 else "mse"
+        if loss not in ("sce", "mse"):
+            raise ValueError("Unknown reconstruction loss. Choose 'sce', "
+                             "'mse' or 'auto'")
+        self.loss_type = loss
+
+        self.mask_token = nn.Parameter(torch.zeros(node_feature_count))
+        self.enc_to_dec = nn.Linear(node_embedding_dim, node_embedding_dim,
+                                    bias=False)
+        self.decoder = CONV_OPTIONS[conv](node_embedding_dim,
+                                          node_feature_count)
+        self.supports_edge_weight = conv in EDGE_WEIGHTED_CONVS
+
+    def apply_mask(self, x, generator=None):
+        """Replace a random subset of each sample's nodes with the mask token.
+
+        The subset is drawn per sample, so a node is hidden in some samples and
+        visible in others and no node is permanently unsupervised.
+        """
+        batch, node_count, _ = x.shape
+        k = max(1, int(round(self.mask_ratio * node_count)))
+        scores = torch.rand(batch, node_count, device=x.device,
+                            generator=generator)
+        idx = scores.argsort(dim=1)[:, :k]
+        mask = torch.zeros(batch, node_count, dtype=torch.bool,
+                           device=x.device)
+        mask.scatter_(1, idx, True)
+        token = self.mask_token.to(x.dtype).view(1, 1, -1)
+        return torch.where(mask.unsqueeze(-1), token, x), mask
+
+    def reconstruct(self, nodes, edge_index, mask, edge_weight=None):
+        nodes = self.enc_to_dec(nodes)
+        # Re-masking: a masked node's own embedding is zeroed before decoding,
+        # so its value can only be rebuilt by travelling along edges.
+        nodes = nodes.masked_fill(mask.unsqueeze(-1), 0.0)
+        if edge_weight is None or not self.supports_edge_weight:
+            return self.decoder(nodes, edge_index)
+        return self.decoder(nodes, edge_index, edge_weight)
+
+    def loss(self, x, x_hat, mask):
+        target, pred = x[mask], x_hat[mask]
+        if target.numel() == 0:
+            return torch.zeros((), device=x.device)
+        if self.loss_type == "mse":
+            return F.mse_loss(pred, target)
+        cos = F.cosine_similarity(pred, target, dim=-1)
+        return (1.0 - cos).pow(self.gamma).mean()
 
 
 def cox_ph_loss(outputs, durations, events):

--- a/flexynesis/utils.py
+++ b/flexynesis/utils.py
@@ -781,14 +781,19 @@ def get_predicted_labels(y_pred_dict, dataset, split, method_name):
                 (
                     dataset.label_mappings[var][int(x.item())]
                     if var in dataset.label_mappings.keys() and not np.isnan(x.item()) and not int(x.item()) == -1
-                    else "Label_not_in_train"  # catches samples ann defaulted to -1 (usually label in test but not in train) # See issue #156
+                    # catches samples ann defaulted to -1, i.e. a label in
+                    # test but not in train. See issue #156
+                    else "Label_not_in_train"
                     if int(x.item()) == -1
-                    else np.nan 
+                    else np.nan
                 )
                 for x in dataset.ann[var]
             ]
-            if "Label_not_in_train" in y_true: # See issue #156
-                print(f"[WARNING] Encoder Defaults. Some {var} values are present in test but not in test") # See issue #156
+            if "Label_not_in_train" in y_true:  # See issue #156
+                print(
+                    f"[WARNING] Encoder Defaults. Some {var} values are "
+                    "present in test but not in test"
+                )
 
             # Predicted labels (argmax of probabilities)
             y_pred_indices = np.argmax(probabilities, axis=1)

--- a/tests/unit/test_edge_weights.py
+++ b/tests/unit/test_edge_weights.py
@@ -1,5 +1,7 @@
 """Edge weights on the GNN graph."""
 
+from itertools import combinations
+
 import pandas as pd
 import pytest
 import torch
@@ -97,7 +99,7 @@ def test_weights_change_the_output():
     assert not torch.allclose(full, none)
 
 
-READOUTS = ["flatten", "mean", "sum", "max", "meanmax"]
+READOUTS = ["mean", "sum", "max", "meanmax", "attention", "dim_attention"]
 
 
 @pytest.mark.parametrize("readout", READOUTS)
@@ -120,8 +122,9 @@ def test_unknown_readout_rejected():
 def test_pooling_readout_is_permutation_invariant():
     """The point of pooling: node order stops carrying information.
 
-    With flatten, relabelling the nodes changes the output, so the model can
-    read a node directly and the graph is optional. With mean it cannot.
+    A readout that kept a weight per node could read a node directly and treat
+    the graph as optional. dim_attention keeps gene identity deliberately; mean
+    does not.
     """
     torch.manual_seed(0)
     x = torch.randn(2, 5, 1)
@@ -137,17 +140,17 @@ def test_pooling_readout_is_permutation_invariant():
     pooled = flexGCN(node_count=5, node_feature_count=1, node_embedding_dim=4,
                      output_dim=3, conv="GCN", readout="mean",
                      dropout_rate=0.0).eval()
-    flat = flexGCN(node_count=5, node_feature_count=1, node_embedding_dim=4,
-                   output_dim=3, conv="GCN", readout="flatten",
-                   dropout_rate=0.0).eval()
+    keyed = flexGCN(node_count=5, node_feature_count=1, node_embedding_dim=4,
+                    output_dim=3, conv="GCN", readout="dim_attention",
+                    project=False, dropout_rate=0.0).eval()
 
     assert torch.allclose(pooled(x, edge_index),
                           pooled(x_perm, edges_perm), atol=1e-5)
-    assert not torch.allclose(flat(x, edge_index), flat(x_perm, edges_perm))
+    assert not torch.allclose(keyed(x, edge_index), keyed(x_perm, edges_perm))
 
 
 def test_pooling_shrinks_the_readout():
-    """Most of the model should stop living in the final layer."""
+    """Most of the model should not live in the final layer."""
     def readout_share(readout):
         model = flexGCN(
             node_count=48, node_feature_count=1, node_embedding_dim=9,
@@ -156,8 +159,8 @@ def test_pooling_shrinks_the_readout():
         total = sum(p.numel() for p in model.parameters())
         return sum(p.numel() for p in model.fc.parameters()) / total
 
-    assert readout_share("flatten") > 0.98
     assert readout_share("mean") < 0.85
+    assert readout_share("dim_attention") < 0.95
 
 
 def test_no_projection_uses_pooled_width():
@@ -187,6 +190,92 @@ def test_no_projection_moves_capacity_into_the_graph():
         convs = sum(p.numel() for c in model.convs for p in c.parameters())
         return convs / total
 
-    assert graph_share(readout="flatten", project=True) < 0.02
     # The rest is batch norm; the readout itself is parameter-free here.
     assert graph_share(readout="mean", project=False) > 0.8
+
+
+def test_attention_is_permutation_equivariant():
+    """Attention scores nodes by content, so relabelling them changes nothing."""
+    torch.manual_seed(0)
+    x = torch.randn(2, 5, 1)
+    edge_index = torch.tensor([[0, 1], [1, 2]])
+    perm = torch.tensor([4, 3, 2, 1, 0])
+    inverse = torch.empty_like(perm)
+    inverse[perm] = torch.arange(len(perm))
+
+    model = flexGCN(node_count=5, node_feature_count=1, node_embedding_dim=4,
+                    output_dim=3, conv="GCN", readout="attention",
+                    dropout_rate=0.0).eval()
+    assert torch.allclose(model(x, edge_index),
+                          model(x[:, perm], inverse[edge_index]), atol=1e-5)
+
+
+def test_attention_weights_are_a_distribution_over_nodes():
+    model = flexGCN(node_count=5, node_feature_count=1, node_embedding_dim=4,
+                    output_dim=3, conv="GCN", readout="attention",
+                    dropout_rate=0.0).eval()
+    model(torch.randn(2, 5, 1), torch.tensor([[0, 1], [1, 2]]))
+    weights = model.last_attention
+    assert weights.shape == (2, 5, 1)
+    assert torch.allclose(weights.sum(dim=1).squeeze(), torch.ones(2), atol=1e-5)
+
+
+def test_attention_can_weight_nodes_unequally():
+    """Unlike mean pooling, attention is not forced to weight every node 1/N."""
+    torch.manual_seed(0)
+    model = flexGCN(node_count=5, node_feature_count=1, node_embedding_dim=4,
+                    output_dim=3, conv="GCN", readout="attention",
+                    dropout_rate=0.0).eval()
+    with torch.no_grad():
+        model.attention.weight.mul_(50.0)
+    model(torch.randn(2, 5, 1), torch.tensor([[0, 1], [1, 2]]))
+    spread = model.last_attention.squeeze(-1).std(dim=1)
+    assert (spread > 1e-3).all()
+
+
+def test_dim_attention_width_is_the_node_count():
+    """One number per gene, so the sample vector is as wide as the graph."""
+    model = flexGCN(node_count=48, node_feature_count=1, node_embedding_dim=16,
+                    output_dim=105, conv="GCN", readout="dim_attention",
+                    project=False)
+    assert model.output_dim == 48
+    x = torch.randn(2, 48, 1)
+    assert model(x, torch.tensor([[0, 1], [1, 2]])).shape == (2, 48)
+
+
+def test_dim_attention_normalises_over_dimensions_not_nodes():
+    model = flexGCN(node_count=5, node_feature_count=1, node_embedding_dim=4,
+                    output_dim=3, conv="GCN", readout="dim_attention",
+                    dropout_rate=0.0).eval()
+    model(torch.randn(2, 5, 1), torch.tensor([[0, 1], [1, 2]]))
+    weights = model.last_attention
+    assert weights.shape == (2, 5, 4)
+    # each node's weights form a distribution across its 4 dimensions
+    assert torch.allclose(weights.sum(dim=2), torch.ones(2, 5), atol=1e-5)
+
+
+def test_dim_attention_keeps_gene_identity():
+    """Unlike node pooling, relabelling nodes must change the output."""
+    torch.manual_seed(0)
+    x = torch.randn(2, 5, 1)
+    edge_index = torch.tensor([[0, 1], [1, 2]])
+    perm = torch.tensor([4, 3, 2, 1, 0])
+    inverse = torch.empty_like(perm)
+    inverse[perm] = torch.arange(len(perm))
+
+    model = flexGCN(node_count=5, node_feature_count=1, node_embedding_dim=4,
+                    output_dim=3, conv="GCN", readout="dim_attention",
+                    project=False, dropout_rate=0.0).eval()
+    assert not torch.allclose(model(x, edge_index),
+                              model(x[:, perm], inverse[edge_index]))
+
+
+def test_dim_attention_is_one_value_per_gene():
+    def width(readout):
+        return flexGCN(node_count=490, node_feature_count=1,
+                       node_embedding_dim=146, output_dim=105, conv="GCN",
+                       readout=readout, project=False).output_dim
+    # One value per gene, not node_embedding_dim values per gene.
+    assert width("dim_attention") == 490
+    assert width("mean") == 146
+

--- a/tests/unit/test_edge_weights.py
+++ b/tests/unit/test_edge_weights.py
@@ -29,11 +29,29 @@ def test_weights_align_with_edges():
     assert edge_weight.tolist() == pytest.approx([1.0, 0.25])
 
 
-def test_zero_weight_edge_is_kept():
-    """A zero weight means "no connection" but must keep the node in the graph."""
+def test_zero_score_is_not_an_edge():
+    """0 means "no connection", so it must not survive as an edge.
+
+    Otherwise a network listing every gene pair reads as fully connected the
+    moment edge weighting is turned off.
+    """
     edge_index, edge_weight = build_edges([("A", "B", 0.0), ("B", "C", 0.5)])
-    assert edge_index.shape == (2, 2)
-    assert edge_weight.tolist() == pytest.approx([0.0, 0.5])
+    assert edge_index.shape == (2, 1)
+    assert edge_weight.tolist() == pytest.approx([0.5])
+
+
+def test_zero_score_row_still_keeps_the_gene_as_a_node():
+    """The all-pairs listing keeps unwired genes in the graph."""
+    import pandas as pd
+
+    dataset = object.__new__(MultiOmicDatasetNW)
+    dataset.multiomic_dataset = type("D", (), {"features": {"m": ["A", "B", "C"]}})()
+    dataset.interaction_df = pd.DataFrame(
+        [("A", "B", 0.5), ("A", "C", 0.0), ("B", "C", 0.0)],
+        columns=["protein1", "protein2", "combined_score"],
+    )
+    # C appears only in zero-score rows, and must still be a node
+    assert "C" in dataset.find_union_features()
 
 
 def test_scores_above_one_are_normalised():
@@ -49,10 +67,12 @@ def test_negative_scores_are_shifted_not_clipped():
     # -1 -> 0, +1 -> 1; a zero correlation would land midway.
     assert edge_weight.tolist() == pytest.approx([0.0, 1.0])
 
+    # A middle value lands midway once the range is shifted and rescaled.
     _, edge_weight = build_edges(
-        [("A", "B", -1.0), ("B", "C", 0.0)], genes=("A", "B", "C")
+        [("A", "B", -1.0), ("B", "C", 0.5), ("A", "C", 1.0)],
+        genes=("A", "B", "C"),
     )
-    assert edge_weight.tolist() == pytest.approx([0.0, 1.0])
+    assert edge_weight.tolist() == pytest.approx([0.0, 0.75, 1.0])
 
 
 def test_edges_outside_the_feature_set_are_dropped():

--- a/tests/unit/test_edge_weights.py
+++ b/tests/unit/test_edge_weights.py
@@ -41,9 +41,15 @@ def test_scores_above_one_are_normalised():
     assert edge_weight.tolist() == pytest.approx([1.0, 0.4])
 
 
-def test_negative_scores_are_clipped():
-    with pytest.warns(UserWarning, match="negative edge scores"):
-        _, edge_weight = build_edges([("A", "B", -0.5), ("B", "C", 1.0)])
+def test_negative_scores_are_shifted_not_clipped():
+    """Anti-correlations keep their ordering instead of collapsing onto 0."""
+    _, edge_weight = build_edges([("A", "B", -1.0), ("B", "C", 1.0)])
+    # -1 -> 0, +1 -> 1; a zero correlation would land midway.
+    assert edge_weight.tolist() == pytest.approx([0.0, 1.0])
+
+    _, edge_weight = build_edges(
+        [("A", "B", -1.0), ("B", "C", 0.0)], genes=("A", "B", "C")
+    )
     assert edge_weight.tolist() == pytest.approx([0.0, 1.0])
 
 

--- a/tests/unit/test_edge_weights.py
+++ b/tests/unit/test_edge_weights.py
@@ -158,3 +158,35 @@ def test_pooling_shrinks_the_readout():
 
     assert readout_share("flatten") > 0.98
     assert readout_share("mean") < 0.85
+
+
+def test_no_projection_uses_pooled_width():
+    """Without the projection the sample embedding is the pooled node vector."""
+    projected = flexGCN(node_count=48, node_feature_count=1,
+                        node_embedding_dim=16, output_dim=105, conv="GCN",
+                        readout="mean", project=True)
+    direct = flexGCN(node_count=48, node_feature_count=1,
+                     node_embedding_dim=16, output_dim=105, conv="GCN",
+                     readout="mean", project=False)
+    assert projected.output_dim == 105
+    assert direct.output_dim == 16
+
+    x = torch.randn(2, 48, 1)
+    edge_index = torch.tensor([[0, 1], [1, 2]])
+    assert projected(x, edge_index).shape == (2, 105)
+    assert direct(x, edge_index).shape == (2, 16)
+
+
+def test_no_projection_moves_capacity_into_the_graph():
+    """The point: most parameters should end up in the convolutions."""
+    def graph_share(**kwargs):
+        model = flexGCN(node_count=48, node_feature_count=1,
+                        node_embedding_dim=16, output_dim=105, num_convs=3,
+                        conv="GCN", **kwargs)
+        total = sum(p.numel() for p in model.parameters())
+        convs = sum(p.numel() for c in model.convs for p in c.parameters())
+        return convs / total
+
+    assert graph_share(readout="flatten", project=True) < 0.02
+    # The rest is batch norm; the readout itself is parameter-free here.
+    assert graph_share(readout="mean", project=False) > 0.8

--- a/tests/unit/test_edge_weights.py
+++ b/tests/unit/test_edge_weights.py
@@ -1,7 +1,5 @@
 """Edge weights on the GNN graph."""
 
-from itertools import combinations
-
 import pandas as pd
 import pytest
 import torch
@@ -162,7 +160,7 @@ def test_pooling_readout_is_permutation_invariant():
                      dropout_rate=0.0).eval()
     keyed = flexGCN(node_count=5, node_feature_count=1, node_embedding_dim=4,
                     output_dim=3, conv="GCN", readout="dim_attention",
-                    project=False, dropout_rate=0.0).eval()
+                    dropout_rate=0.0).eval()
 
     assert torch.allclose(pooled(x, edge_index),
                           pooled(x_perm, edges_perm), atol=1e-5)
@@ -183,35 +181,14 @@ def test_pooling_shrinks_the_readout():
     assert readout_share("dim_attention") < 0.95
 
 
-def test_no_projection_uses_pooled_width():
-    """Without the projection the sample embedding is the pooled node vector."""
-    projected = flexGCN(node_count=48, node_feature_count=1,
-                        node_embedding_dim=16, output_dim=105, conv="GCN",
-                        readout="mean", project=True)
-    direct = flexGCN(node_count=48, node_feature_count=1,
-                     node_embedding_dim=16, output_dim=105, conv="GCN",
-                     readout="mean", project=False)
-    assert projected.output_dim == 105
-    assert direct.output_dim == 16
-
+def test_projection_sets_the_sample_width():
+    """The readout is always projected into output_dim."""
+    model = flexGCN(node_count=48, node_feature_count=1,
+                    node_embedding_dim=16, output_dim=105, conv="GCN",
+                    readout="mean")
+    assert model.output_dim == 105
     x = torch.randn(2, 48, 1)
-    edge_index = torch.tensor([[0, 1], [1, 2]])
-    assert projected(x, edge_index).shape == (2, 105)
-    assert direct(x, edge_index).shape == (2, 16)
-
-
-def test_no_projection_moves_capacity_into_the_graph():
-    """The point: most parameters should end up in the convolutions."""
-    def graph_share(**kwargs):
-        model = flexGCN(node_count=48, node_feature_count=1,
-                        node_embedding_dim=16, output_dim=105, num_convs=3,
-                        conv="GCN", **kwargs)
-        total = sum(p.numel() for p in model.parameters())
-        convs = sum(p.numel() for c in model.convs for p in c.parameters())
-        return convs / total
-
-    # The rest is batch norm; the readout itself is parameter-free here.
-    assert graph_share(readout="mean", project=False) > 0.8
+    assert model(x, torch.tensor([[0, 1], [1, 2]])).shape == (2, 105)
 
 
 def test_attention_is_permutation_equivariant():
@@ -254,13 +231,12 @@ def test_attention_can_weight_nodes_unequally():
 
 
 def test_dim_attention_width_is_the_node_count():
-    """One number per gene, so the sample vector is as wide as the graph."""
+    """One number per gene, so the readout is as wide as the graph."""
     model = flexGCN(node_count=48, node_feature_count=1, node_embedding_dim=16,
-                    output_dim=105, conv="GCN", readout="dim_attention",
-                    project=False)
-    assert model.output_dim == 48
+                    output_dim=105, conv="GCN", readout="dim_attention")
+    assert model.fc.in_features == 48
     x = torch.randn(2, 48, 1)
-    assert model(x, torch.tensor([[0, 1], [1, 2]])).shape == (2, 48)
+    assert model(x, torch.tensor([[0, 1], [1, 2]])).shape == (2, 105)
 
 
 def test_dim_attention_normalises_over_dimensions_not_nodes():
@@ -285,7 +261,7 @@ def test_dim_attention_keeps_gene_identity():
 
     model = flexGCN(node_count=5, node_feature_count=1, node_embedding_dim=4,
                     output_dim=3, conv="GCN", readout="dim_attention",
-                    project=False, dropout_rate=0.0).eval()
+                    dropout_rate=0.0).eval()
     assert not torch.allclose(model(x, edge_index),
                               model(x[:, perm], inverse[edge_index]))
 
@@ -294,8 +270,7 @@ def test_dim_attention_is_one_value_per_gene():
     def width(readout):
         return flexGCN(node_count=490, node_feature_count=1,
                        node_embedding_dim=146, output_dim=105, conv="GCN",
-                       readout=readout, project=False).output_dim
+                       readout=readout).fc.in_features
     # One value per gene, not node_embedding_dim values per gene.
     assert width("dim_attention") == 490
     assert width("mean") == 146
-

--- a/tests/unit/test_edge_weights.py
+++ b/tests/unit/test_edge_weights.py
@@ -1,0 +1,91 @@
+"""Edge weights on the GNN graph."""
+
+import pandas as pd
+import pytest
+import torch
+
+from flexynesis.data import MultiOmicDatasetNW
+from flexynesis.modules import flexGCN
+
+
+def build_edges(pairs_and_scores, genes=("A", "B", "C")):
+    """Run create_edge_index against a hand-built interaction table."""
+    dataset = object.__new__(MultiOmicDatasetNW)
+    dataset.interaction_df = pd.DataFrame(
+        [(a, b, s) for a, b, s in pairs_and_scores],
+        columns=["protein1", "protein2", "combined_score"],
+    )
+    dataset.common_features = list(genes)
+    dataset.gene_to_index = {g: i for i, g in enumerate(genes)}
+    return dataset.create_edge_index()
+
+
+def test_weights_align_with_edges():
+    edge_index, edge_weight = build_edges([("A", "B", 1.0), ("B", "C", 0.25)])
+    assert edge_index.shape == (2, 2)
+    assert edge_index.dtype == torch.long
+    assert edge_weight.tolist() == pytest.approx([1.0, 0.25])
+
+
+def test_zero_weight_edge_is_kept():
+    """A zero weight means "no connection" but must keep the node in the graph."""
+    edge_index, edge_weight = build_edges([("A", "B", 0.0), ("B", "C", 0.5)])
+    assert edge_index.shape == (2, 2)
+    assert edge_weight.tolist() == pytest.approx([0.0, 0.5])
+
+
+def test_scores_above_one_are_normalised():
+    """STRING's native 0-1000 combined scores rescale without caller action."""
+    _, edge_weight = build_edges([("A", "B", 1000.0), ("B", "C", 400.0)])
+    assert edge_weight.max().item() == pytest.approx(1.0)
+    assert edge_weight.tolist() == pytest.approx([1.0, 0.4])
+
+
+def test_negative_scores_are_clipped():
+    with pytest.warns(UserWarning, match="negative edge scores"):
+        _, edge_weight = build_edges([("A", "B", -0.5), ("B", "C", 1.0)])
+    assert edge_weight.tolist() == pytest.approx([0.0, 1.0])
+
+
+def test_edges_outside_the_feature_set_are_dropped():
+    edge_index, edge_weight = build_edges(
+        [("A", "B", 1.0), ("A", "Z", 1.0)], genes=("A", "B")
+    )
+    assert edge_index.shape == (2, 1)
+    assert edge_weight.tolist() == pytest.approx([1.0])
+
+
+@pytest.mark.parametrize("conv,supported", [("GCN", True), ("GC", True),
+                                            ("SAGE", False)])
+def test_conv_edge_weight_support(conv, supported):
+    model = flexGCN(
+        node_count=3, node_feature_count=1, node_embedding_dim=4,
+        output_dim=2, conv=conv,
+    )
+    assert model.supports_edge_weight is supported
+
+    x = torch.randn(2, 3, 1)
+    edge_index = torch.tensor([[0, 1], [1, 2]])
+    edge_weight = torch.tensor([1.0, 0.0])
+
+    if supported:
+        assert model(x, edge_index, edge_weight).shape == (2, 2)
+    else:
+        # SAGEConv has no slot for a weight; it must warn rather than crash.
+        with pytest.warns(UserWarning, match="ignores"):
+            assert model(x, edge_index, edge_weight).shape == (2, 2)
+
+
+def test_weights_change_the_output():
+    """Guard against the weights being accepted and then silently ignored."""
+    torch.manual_seed(0)
+    model = flexGCN(
+        node_count=3, node_feature_count=1, node_embedding_dim=4,
+        output_dim=2, conv="GCN", dropout_rate=0.0,
+    ).eval()
+    x = torch.randn(2, 3, 1)
+    edge_index = torch.tensor([[0, 1], [1, 2]])
+
+    full = model(x, edge_index, torch.tensor([1.0, 1.0]))
+    none = model(x, edge_index, torch.tensor([0.0, 0.0]))
+    assert not torch.allclose(full, none)

--- a/tests/unit/test_edge_weights.py
+++ b/tests/unit/test_edge_weights.py
@@ -95,3 +95,66 @@ def test_weights_change_the_output():
     full = model(x, edge_index, torch.tensor([1.0, 1.0]))
     none = model(x, edge_index, torch.tensor([0.0, 0.0]))
     assert not torch.allclose(full, none)
+
+
+READOUTS = ["flatten", "mean", "sum", "max", "meanmax"]
+
+
+@pytest.mark.parametrize("readout", READOUTS)
+def test_readout_shapes(readout):
+    model = flexGCN(
+        node_count=5, node_feature_count=1, node_embedding_dim=4,
+        output_dim=3, conv="GCN", readout=readout,
+    )
+    x = torch.randn(2, 5, 1)
+    edge_index = torch.tensor([[0, 1, 2], [1, 2, 3]])
+    assert model(x, edge_index).shape == (2, 3)
+
+
+def test_unknown_readout_rejected():
+    with pytest.raises(ValueError):
+        flexGCN(node_count=5, node_feature_count=1, node_embedding_dim=4,
+                output_dim=3, readout="nonsense")
+
+
+def test_pooling_readout_is_permutation_invariant():
+    """The point of pooling: node order stops carrying information.
+
+    With flatten, relabelling the nodes changes the output, so the model can
+    read a node directly and the graph is optional. With mean it cannot.
+    """
+    torch.manual_seed(0)
+    x = torch.randn(2, 5, 1)
+    edge_index = torch.tensor([[0, 1], [1, 2]])
+
+    # Relabel the nodes: the graph is the same, only the ordering changes, so
+    # the edges have to be remapped too or this is a different graph.
+    perm = torch.tensor([4, 3, 2, 1, 0])
+    inverse = torch.empty_like(perm)
+    inverse[perm] = torch.arange(len(perm))
+    x_perm, edges_perm = x[:, perm], inverse[edge_index]
+
+    pooled = flexGCN(node_count=5, node_feature_count=1, node_embedding_dim=4,
+                     output_dim=3, conv="GCN", readout="mean",
+                     dropout_rate=0.0).eval()
+    flat = flexGCN(node_count=5, node_feature_count=1, node_embedding_dim=4,
+                   output_dim=3, conv="GCN", readout="flatten",
+                   dropout_rate=0.0).eval()
+
+    assert torch.allclose(pooled(x, edge_index),
+                          pooled(x_perm, edges_perm), atol=1e-5)
+    assert not torch.allclose(flat(x, edge_index), flat(x_perm, edges_perm))
+
+
+def test_pooling_shrinks_the_readout():
+    """Most of the model should stop living in the final layer."""
+    def readout_share(readout):
+        model = flexGCN(
+            node_count=48, node_feature_count=1, node_embedding_dim=9,
+            output_dim=105, num_convs=3, conv="GCN", readout=readout,
+        )
+        total = sum(p.numel() for p in model.parameters())
+        return sum(p.numel() for p in model.fc.parameters()) / total
+
+    assert readout_share("flatten") > 0.98
+    assert readout_share("mean") < 0.85


### PR DESCRIPTION
GNN updates: edge weights, readouts, and a masked-reconstruction objective

**Edge weights** are now read from the user graph and passed to the
convolutions that accept them (GCN, GC), on by default with
`--disable_edge_weighting` to opt out. Negative scores are shifted rather
than clipped; a zero score means no edge.

**Readouts** are selectable via `--gnn_readout`: the pooling options
(`mean`/`sum`/`max`/`meanmax`/`attention`), `dim_attention`, and `flatten`.

**GraphMAE** (Hou et al. 2022) adds masked node-feature reconstruction as an
auxiliary objective, always on. A fraction of each sample's nodes is replaced
by a learned mask token and rebuilt from its neighbours alone. The mask ratio
is a tuned hyperparameter; pinning `gnn_mask_ratio: 0` in a config disables
it. The term is balanced by the existing uncertainty weighting, registered the
same way `supervised_vae` registers `mmd_loss`.

Also: `--seed` for reproducible runs 