### PR TITLE
Inference typeerror Additional Columns

### DIFF
--- a/flexynesis/data.py
+++ b/flexynesis/data.py
@@ -851,7 +851,7 @@ class DataImporterInference:
                 test_data[modality] = torch.from_numpy(df_reordered.values).float()
 
             samples = common_samples
-
+            failed_colums = []
             for col in labels_df.columns:
                 if col in self.label_encoders:
                     encoder = self.label_encoders[col]
@@ -881,8 +881,14 @@ class DataImporterInference:
 
                     label_mappings[col][-1] = "Unknown"  # For missing values
                 else:
-                    ann_dict[col] = torch.from_numpy(labels_df[col].values).float()
-                    variable_types[col] = "numerical"
+                    try:
+                        ann_dict[col] = torch.from_numpy(labels_df[col].values).float()
+                        variable_types[col] = "numerical"
+                    except (ValueError, TypeError): #this is a bandaid fix and should be replace by a if els ethat checks the colum on numerics beforehand
+                        failed_colums.append(col)
+
+                print(f"[INFO] Feature(s) could not be encoded and will be ignored: {failed_colums}")
+
 
         # Create features dict
         # For early fusion, get features from scalers since feature_lists only has 'all'

--- a/flexynesis/data.py
+++ b/flexynesis/data.py
@@ -855,7 +855,7 @@ class DataImporterInference:
                 test_data[modality] = torch.from_numpy(df_reordered.values).float()
 
             samples = common_samples
-
+            failed_colums = []
             for col in labels_df.columns:
                 if col in self.label_encoders:
                     encoder = self.label_encoders[col]
@@ -885,8 +885,14 @@ class DataImporterInference:
 
                     label_mappings[col][-1] = "Unknown"  # For missing values
                 else:
-                    ann_dict[col] = torch.from_numpy(labels_df[col].values).float()
-                    variable_types[col] = "numerical"
+                    try:
+                        ann_dict[col] = torch.from_numpy(labels_df[col].values).float()
+                        variable_types[col] = "numerical"
+                    except (ValueError, TypeError): #this is a bandaid fix and should be replace by a if els ethat checks the colum on numerics beforehand
+                        failed_colums.append(col)
+
+                print(f"[INFO] Feature(s) could not be encoded and will be ignored: {failed_colums}")
+
 
         # Create features dict
         # For early fusion, get features from scalers since feature_lists only has 'all'

--- a/flexynesis/data.py
+++ b/flexynesis/data.py
@@ -885,14 +885,14 @@ class DataImporterInference:
 
                     label_mappings[col][-1] = "Unknown"  # For missing values
                 else:
-                    try:
+                    if np.issubdtype(labels_df[col].dtype, np.number):
                         ann_dict[col] = torch.from_numpy(labels_df[col].values).float()
                         variable_types[col] = "numerical"
-                    except (ValueError, TypeError): #this is a bandaid fix and should be replace by a if els ethat checks the colum on numerics beforehand
+                    else:
                         failed_colums.append(col)
 
-                print(f"[INFO] Feature(s) could not be encoded and will be ignored: {failed_colums}")
-
+            print(f"[INFO] Feature(s) could not be encoded and will be ignored: {failed_colums}")
+            labels_df.drop(columns=failed_colums, inplace=True)
 
         # Create features dict
         # For early fusion, get features from scalers since feature_lists only has 'all'


### PR DESCRIPTION
Error in Inference Mode:
- If inference/finetune dataset has a non numerical  column that was not in original encoding and therefore has no encoder stored in .joblib the default nimerical branch would throw an error.
- now check before default numerical encoding check if column is numerical else collect and then drop not encoded columns.  
